### PR TITLE
Set max preview width

### DIFF
--- a/web/public/index.css
+++ b/web/public/index.css
@@ -14,6 +14,7 @@ menu {
   margin: 0;
   display: flex;
   justify-content: space-between;
+  max-width: 950px;
 }
 
 menu a {
@@ -32,6 +33,11 @@ menu a:hover {
 menu a.active {
   background: #333;
   color: white;
+}
+
+pre {
+  max-width: 950px;
+  overflow-x: scroll;
 }
 
 .spinner {


### PR DESCRIPTION
Prior to this PR, an unusually wide JSON response (meaning, a single string property in the object had a large length) would cause the size of the preview window to grow to match. This PR changes that behavior to set an upper bounds for the width.

Fixes #45
