### PR TITLE
Add browser dark-mode support

### DIFF
--- a/web/public/index.css
+++ b/web/public/index.css
@@ -57,3 +57,10 @@ pre {
     transform: rotate(360deg);
   }
 }
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background-color: #1f1f1f;
+    color: #ffffff;
+  }
+}

--- a/web/public/trmnl-component.js
+++ b/web/public/trmnl-component.js
@@ -204,7 +204,7 @@
 
 
 
-                       <foreignobject  class="node" x="36" y="34" width="840" height="520"
+                       <foreignobject  class="node" x="36" y="34" width="830" height="520"
                                       style="transform:scale(0.98);  position: relative;  border-radius: 12px; opacity: 0.9; mix-blend-mode: darken;">
                          <div id="${contentWrapperId}"
                              style="position: static; width: 100%; height: 100%;  max-width: 100%; max-height: 100%;">


### PR DESCRIPTION
Adds dark mode styling for the outer container.[^1]

![Screenshot 2025-06-19 at 8 57 30 PM](https://github.com/user-attachments/assets/4972ec97-4a7e-401a-91b3-621c4dacd496)

[^1]: This is **not** dark mode on the device preview itself. That appears to be in progress.