### PR TITLE
Automatically remove ephemeral docker container upon exit

### DIFF
--- a/templates/init/bin/trmnlp
+++ b/templates/init/bin/trmnlp
@@ -13,6 +13,7 @@ fi
 if command -v docker &> /dev/null
 then
     docker run \
+        --rm \
         --publish 4567:4567 \
         --volume "$(pwd):/plugin" \
         trmnl/trmnlp "$@"


### PR DESCRIPTION
The `trmnlp` via docker container should be only ephemeral and temporary. It should not clutter the environment with stopped containers, as seen with `docker ps -a`.