### PR TITLE
Copy templates directory to Docker image for init command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ COPY Gemfile \
 COPY lib/ /app/lib/
 COPY web/ /app/web/
 COPY bin/ /app/bin/
+COPY templates/ /app/templates/
 
 RUN bundle install
 


### PR DESCRIPTION
The `init` command creates an empty plugin directory when run via Docker.

```bash
docker run --volume ".:/plugin" trmnl/trmnlp init my_plugin
```

This creates the `my_plugin` folder but it is completely empty, with no template files.

Turns out the `Dockerfile` is missing the `templates/` directory in the `COPY` commands. The `init` command relies on the template files at `/app/templates` to populate new plugin projects.

This PR adds `COPY templates/ /app/templates/` to the `Dockerfile`.

After the fix, the `init` command worked correctly and created a properly populated plugin directory.