### PR TITLE
Auth: accept API key from env variable

### DIFF
--- a/lib/trmnlp/commands/login.rb
+++ b/lib/trmnlp/commands/login.rb
@@ -6,7 +6,9 @@ module TRMNLP
       def call
         if config.app.logged_in?
           anonymous_key = config.app.api_key[0..10] + '*' * (config.app.api_key.length - 11)
-          output "Currently authenticated as: #{anonymous_key}" 
+          output "Currently authenticated as: #{anonymous_key}"
+          confirm = prompt("You are already authenticated. Do you want to re-authenticate? (y/N): ")
+          return unless confirm.strip.downcase == 'y'
         end
 
         output "Please visit #{config.app.account_uri} to grab your API key, then paste it here."

--- a/lib/trmnlp/config/app.rb
+++ b/lib/trmnlp/config/app.rb
@@ -17,7 +17,11 @@ module TRMNLP
       def logged_in? = api_key && !api_key.empty?
       def logged_out? = !logged_in?
 
-      def api_key = @config['api_key']
+      def api_key
+        env_api_key = ENV['TRMNL_API_KEY']
+        return env_api_key if env_api_key && !env_api_key.empty?
+        @config['api_key']
+      end
 
       def api_key=(key)
         @config['api_key'] = key


### PR DESCRIPTION
This PR adds two improvements to the auth mechanism:

#### 12-Factor style env variable support
  - the App config checks for the presence of `TRMNL_API_KEY`, following 12-factor app best practices. My use case is plugin update via GitHub CI/CD Pipeline. It would look like this:
```yml
step:
  # ...
  name: Push plugin
  env:
    TRMNL_API_KEY: ${{ secrets.TRMNL_API_KEY }}
  run: trmnlp push
```
  - if env var not available, application stays with old behaviour of prompting for API key
  - env var has the highest precedence, i.e. when both API key in `config.yml` and env var exists, the value from env var will be used. 

#### Re-authentication prompt
  - if a user is already authenticated, the command now prompts to confirm if they wish to re-auth, and exits early if not.