### PR TITLE
Support persistent config and interactive login in Docker

### DIFF
--- a/templates/init/bin/trmnlp
+++ b/templates/init/bin/trmnlp
@@ -10,6 +10,17 @@ then
     exit
 fi
 
+# Determine XDG config directory on host OS
+if [ -n "$XDG_CONFIG_HOME" ]; then
+    CONFIG_DIR="$XDG_CONFIG_HOME/trmnlp"
+else
+    CONFIG_DIR="$HOME/.config/trmnlp"
+fi
+
+if [ ! -d "$CONFIG_DIR" ]; then
+    mkdir -p "$CONFIG_DIR"
+fi
+
 if command -v docker &> /dev/null
 then
     docker run \
@@ -17,7 +28,7 @@ then
         --rm \
         --publish 4567:4567 \
         --volume "$(pwd):/plugin" \
-        --volume "/root/.config/trmnlp:/root/.config/trmnlp" \
+        --volume "$CONFIG_DIR:/root/.config/trmnlp" \
         trmnl/trmnlp "$@"
     exit
 fi


### PR DESCRIPTION
When running `bin/trmnlp login` or `docker run --volume ".:/plugin" trmnl/trmnlp login`, the login prompt fails.

```
/app/lib/trmnlp/commands/base.rb:36:in 'TRMNLP::Commands::Base#prompt': undefined method 'chomp' for nil (NoMethodError)

        $stdin.gets.chomp
                   ^^^^^^
        from /app/lib/trmnlp/commands/login.rb:16:in 'TRMNLP::Commands::Login#call'
        from /app/lib/trmnlp/cli.rb:26:in 'TRMNLP::CLI#login'
        from /usr/local/bundle/gems/thor-1.3.2/lib/thor/command.rb:28:in 'Thor::Command#run'
        from /usr/local/bundle/gems/thor-1.3.2/lib/thor/invocation.rb:127:in 'Thor::Invocation#invoke_command'
        from /usr/local/bundle/gems/thor-1.3.2/lib/thor.rb:538:in 'Thor.dispatch'
        from /usr/local/bundle/gems/thor-1.3.2/lib/thor/base.rb:584:in 'Thor::Base::ClassMethods#start'
        from /app/bin/trmnlp:11:in '<main>'
Please visit https://usetrmnl.com/account to grab your API key, then paste it here.
API Key: % 
```

Adding the `-it` flags to `docker run` enables interactive input, allowing the login prompt to work as expected.

Additionally, I noticed that the generated `config.yml` was not persisted after the login command completed. Mounting the config directory ensures it persists across container runs.