### PR TITLE
Safer docker run line

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ trmnlp serve
 ```sh
 docker run \
     --publish 4567:4567 \
-    --volume ".:/plugin" \
+    --volume "$(pwd):/plugin" \
     trmnl/trmnlp serve
 ```
 


### PR DESCRIPTION
dot not always passes for the current directory (try latest macos). Using the pwd will always substitute proper path to docker.