### PR TITLE
Add newer Liquid filters

### DIFF
--- a/lib/markup/custom_liquid_filters.rb
+++ b/lib/markup/custom_liquid_filters.rb
@@ -1,5 +1,7 @@
 require 'action_view'
 require 'singleton'
+require 'redcarpet'
+require 'securerandom'
 
 module Markup
   module CustomLiquidFilters
@@ -9,11 +11,11 @@ module Markup
     end
 
     def number_with_delimiter(number, delimiter = ',', separator = ',')
-      ActionViewHelpers.instance.number_with_delimiter(number, delimiter:, separator:)
+      ActionViewHelpers.instance.number_with_delimiter(number, delimiter: delimiter, separator: separator)
     end
 
     def number_to_currency(number, unit = '$', delimiter = ',', separator = '.')
-      ActionViewHelpers.instance.number_to_currency(number, unit: unit, delimiter:, separator:)
+      ActionViewHelpers.instance.number_to_currency(number, unit: unit, delimiter: delimiter, separator: separator)
     end
 
     def l_word(word, locale)
@@ -31,6 +33,35 @@ module Markup
 
     def json(obj)
       JSON.generate(obj)
+    end
+
+    # Collections filters
+    def group_by(collection, key)
+      return {} unless collection.is_a?(Array)
+      collection.group_by { |item| item[key] }
+    end
+
+    def find_by(collection, key, value, fallback = nil)
+      return fallback unless collection.is_a?(Array)
+      found = collection.find { |item| item[key] == value }
+      found || fallback
+    end
+
+    # String, markup, HTML filters
+    def markdown_to_html(text)
+      renderer = Redcarpet::Render::HTML.new
+      markdown = Redcarpet::Markdown.new(renderer)
+      markdown.render(text)
+    end
+
+    # Date filters
+    def days_ago(days)
+      (Time.now - (days.to_i * 24 * 60 * 60)).strftime('%Y-%m-%d')
+    end
+
+    # Uniqueness filters
+    def append_random(string)
+      "#{string}#{SecureRandom.alphanumeric(4).downcase}"
     end
   end
 end

--- a/trmnl_preview.gemspec
+++ b/trmnl_preview.gemspec
@@ -46,6 +46,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "liquid", "~> 5.6"
   spec.add_dependency "activesupport", "~> 8.0"
   spec.add_dependency "actionview", "~> 8.0"
+  spec.add_dependency "redcarpet", "~> 3.6"
 
   # PNG rendering
   spec.add_dependency 'puppeteer-ruby', '~> 0.45.6'


### PR DESCRIPTION
Found myself trying to use `group_by` in a plugin, finally figured out why it worked in the web editor by not in `trmnlp`. Implementation details below are likely different from how it's done upstream, but this at least let me keep working.