### PR TITLE
fix: allow semicolon as URI separator

### DIFF
--- a/lib/trmnlp/context.rb
+++ b/lib/trmnlp/context.rb
@@ -71,9 +71,12 @@ module TRMNLP
       config.plugin.polling_urls.each.with_index do |url, i|
         verb = config.plugin.polling_verb.upcase
 
-        print "#{verb} #{url}... "
+        # Convert semicolons to ampersands in query parameters for compatibility
+        normalized_url = url.gsub(/;/, '&')
 
-        conn = Faraday.new(url:, headers: config.plugin.polling_headers)
+        print "#{verb} #{normalized_url}... "
+
+        conn = Faraday.new(normalized_url:, headers: config.plugin.polling_headers)
 
         case verb
         when 'GET'


### PR DESCRIPTION
While semicolons are no longer supported as a valid separator (since w3c's 2014 recommendations), I've come across a couple of APIs that still use them (e.g. <http://openaccess.pf.api.met.ie/metno-wdb2ts/locationforecast?lat=53.3656166;long=-6.2336893>). 

These URLs are supported by trmnl itself if used as polling URLs within plugins created through their dashboard. However trmnlp uses faraday which encodes semicolons to `%3B` and results in an invalid request. 

This PR cleans the URL to convert semicolons into ampersands before passing it to faraday, allowing the use of both ampersands and semicolons as separators.