### PR TITLE
Add trmnlp list command to list private plugins from TRMNL server

### DIFF
--- a/lib/trmnlp/api_client.rb
+++ b/lib/trmnlp/api_client.rb
@@ -9,6 +9,16 @@ module TRMNLP
       @config = config
     end
 
+    def get_plugin_settings
+      response = conn.get("plugin_settings")
+
+      if response.status == 200
+        JSON.parse(response.body)
+      else
+        raise Error, "failed to list plugin settings: #{response.status} #{response.body}"
+      end
+    end
+
     def get_plugin_setting_archive(id)
       response = conn.get("plugin_settings/#{id}/archive")
 

--- a/lib/trmnlp/cli.rb
+++ b/lib/trmnlp/cli.rb
@@ -37,6 +37,11 @@ module TRMNLP
       Commands::Clone.new(options).call(name, id)
     end
 
+    desc 'list', 'List private plugins from TRMNL server'
+    def list
+      Commands::List.new(options).call
+    end
+
     desc 'pull', 'Download latest plugin settings from TRMNL server'
     method_option :force, type: :boolean, default: false, aliases: '-f',
                   desc: 'Skip confirmation prompts'

--- a/lib/trmnlp/commands/list.rb
+++ b/lib/trmnlp/commands/list.rb
@@ -1,0 +1,34 @@
+require_relative 'base'
+require_relative '../api_client'
+
+module TRMNLP
+  module Commands
+    class List < Base
+      def call
+        authenticate!
+
+        api = APIClient.new(config)
+        response = api.get_plugin_settings
+        plugins = (response['data'] || [])
+          .select { |p| p['plugin_id'] == 37 }
+          .sort_by { |p| (p['name'] || '').downcase }
+
+        if plugins.empty?
+          output "No plugins found."
+          return
+        end
+
+        output "Your plugins:\n\n"
+        output "  %-8s  %s" % ["ID", "NAME"]
+        output "  " + "-" * 50
+
+        plugins.each do |plugin|
+          output "  %-8s  %s" % [plugin['id'], plugin['name']]
+        end
+
+        output "\nTo clone a plugin:"
+        output "    trmnlp clone [folder_name] [id]"
+      end
+    end
+  end
+end


### PR DESCRIPTION
A sample output in docker


```
root@88d373f0092b:/plugin# trmnlp list
bash: trmnlp: command not found
root@88d373f0092b:/plugin# /app/bin/trmnlp list
Your plugins:

  ID        NAME
  --------------------------------------------------
  65474     Air Quality Monitor
  34845     Anagram Puzzle
  32162     Apple Steps
  40821     Book of the day
  59188     Crypto Market Status
  189403    Current active volcanos
  30789     Cyanide and Happiness Comics
  30775     Daily Horoscope
  32147     Daily Horoscope -2
  68746     Dashboard
  198850    Follower count
  45484     Global Stock Market
  45476     GSOL
  35788     Hourly Weather Forecast
  216760    Hourly Weather Forecast - Migration
  189324    Hourly Weather Forecast V2
  199635    ISS Piss tracker
  30458     Lichess Daily Puzzle
  180898    Metal Price Tracker
  181032    Plant watering Schedule
  29308     Simple Calendar
  233168    Simple To-do
  42282     Sudoku of the day
  29557     Sunrise and Sunset
  63494     Travel Time
  184160    Travel Time
  29604     TRMNL Battery Status
  65351     Weather Chum
  30385     Who's That Pokémon?
  33259     Word of the Day (Eng)
  66588     World Clock
  30378     XKCD

To clone a plugin:
    trmnlp clone [folder_name] [id]
root@88d373f0092b:/plugin# 

```