### PR TITLE
Disable subpixel text rendering

### DIFF
--- a/lib/trmnlp/screen_generator.rb
+++ b/lib/trmnlp/screen_generator.rb
@@ -83,6 +83,8 @@ module TRMNLP
         options = Selenium::WebDriver::Firefox::Options.new
         options.add_argument('--headless')
         options.add_argument('--disable-web-security')
+        options.add_preference('gfx.text.disable-aa', true)
+        options.add_preference('gfx.text.subpixel-position.force-disabled', true)
 
         driver = Selenium::WebDriver.for(:firefox, options: options)
         # Set a default window size that will be consistent


### PR DESCRIPTION
This PR disable subpixel rendering in Firefox to improve text rendering appearance when the layout may land some text in subpixel positions.

Below is an example of the same HTML source rendered before and after this change.

| Before |
|:--:|
| <img width="800" height="480" alt="image" src="https://github.com/user-attachments/assets/e33ad044-6726-421e-b731-491af760f20b" /> |
| **After** |
| <img width="800" height="480" alt="screenshot copy" src="https://github.com/user-attachments/assets/0b8ccc22-960c-4d85-b311-7f044c73d4ef" /> |
