### PR TITLE
Fix Docker interactive mode usage by adding symbolic link to /app/bin/trmlp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,8 @@ COPY web/ /app/web/
 COPY bin/ /app/bin/
 COPY templates/ /app/templates/
 
+RUN ln -s /app/bin/trmnlp /usr/local/bin/trmnlp
+
 EXPOSE 4567
 WORKDIR /plugin
 ENTRYPOINT [ "/app/bin/trmnlp" ]


### PR DESCRIPTION
As it stands in the readme, the interactive mode usage of `trmnlp` does not work properly.
The bin for the app does not exist for the user when entry point becomes `/usr/bin/bash`.
One can obviously call `/app/bin/trmnlp` but that is a bit unwieldy and not true to what the readme says.

```sh
m$ docker run -it     --publish 4567:4567     --volume "$HOME/.config/trmnlp:/root/.config/trmnlp"     --volume "$(pwd):/plugin"     --entrypoint /usr/bin/bash     trmnl/trmnlp
root@8e8cd9e2742a:/plugin# which trmnlp
root@8e8cd9e2742a:/plugin# trmnlp
bash: trmnlp: command not found
```

I propose a simple fix - symbolic link in the `Dockerfile`, which allows for proper `trmnlp` command usage when inside of the container.

```sh
m$ docker run -it     --publish 4567:4567     --volume "$HOME/.config/trmnlp:/root/.config/trmnlp"     --volume "$(pwd):/plugin"     --entrypoint /usr/bin/bash     trmnlp:latest
root@7d2cf81cf5c9:/plugin# which trmnlp
/usr/local/bin/trmnlp
root@7d2cf81cf5c9:/plugin# trmnlp 
trmnlp commands:
  trmnlp build           # Generate static HTML files
  trmnlp clone NAME ID   # Copy a plugin project from TRMNL server
  trmnlp help [COMMAND]  # Describe available commands or one specific command
  trmnlp init NAME       # Start a new plugin project
  trmnlp list            # List private plugins from TRMNL server
  trmnlp login           # Authenticate with TRMNL server
  trmnlp pull            # Download latest plugin settings from TRMNL server
  trmnlp push            # Upload latest plugin settings to TRMNL server
  trmnlp serve           # Start a local dev server
  trmnlp version         # Show version
[...truncated]
```

