### PR TITLE
Fix device width/height in user-data JSON to reflect selected model

### DIFF
--- a/lib/trmnlp/app.rb
+++ b/lib/trmnlp/app.rb
@@ -46,7 +46,9 @@ module TRMNLP
 
     get '/data' do
       content_type :json
-      JSON.pretty_generate(@context.user_data)
+      device_width = params[:device_width] && params[:device_width].to_i
+      device_height = params[:device_height] && params[:device_height].to_i
+      JSON.pretty_generate(@context.user_data(device_width: device_width, device_height: device_height))
     end
 
     get '/live_reload' do

--- a/lib/trmnlp/context.rb
+++ b/lib/trmnlp/context.rb
@@ -47,8 +47,8 @@ module TRMNLP
       @view_change_callback = block
     end
 
-    def user_data
-      merged_data = base_trmnl_data
+    def user_data(device_width: nil, device_height: nil)
+      merged_data = base_trmnl_data(device_width: device_width, device_height: device_height)
 
       if config.plugin.static?
         merged_data.merge!(config.plugin.static_data)
@@ -182,7 +182,7 @@ module TRMNLP
       json.is_a?(Array) ? { data: json } : json
     end
 
-    def base_trmnl_data
+    def base_trmnl_data(device_width: nil, device_height: nil)
       tz = ActiveSupport::TimeZone.find_tzinfo(config.project.time_zone)
       time_zone_iana = tz.name
       time_zone_name = ActiveSupport::TimeZone::MAPPING.invert[time_zone_iana] || time_zone_iana
@@ -203,8 +203,8 @@ module TRMNLP
             'friendly_id' => 'ABC123',
             'percent_charged' => 85.0,
             'wifi_strength' => 90,
-            'height' => 480,
-            'width' => 800
+            'height' => device_height || 480,
+            'width' => device_width || 800
           },
           'system' => {
             'timestamp_utc' => Time.now.utc.to_i,

--- a/spec/lib/trmnlp/context_spec.rb
+++ b/spec/lib/trmnlp/context_spec.rb
@@ -4,6 +4,40 @@ RSpec.describe TRMNLP::Context do
   let(:root_dir) { File.join(__dir__, '../../fixtures') }
   subject(:context) { described_class.new(root_dir) }
 
+  describe '#user_data' do
+    context 'with default device dimensions' do
+      it 'uses 800x480 as default device dimensions' do
+        data = context.user_data
+        expect(data['trmnl']['device']['width']).to eq(800)
+        expect(data['trmnl']['device']['height']).to eq(480)
+      end
+    end
+
+    context 'with custom device dimensions' do
+      it 'uses the provided width and height' do
+        data = context.user_data(device_width: 1024, device_height: 600)
+        expect(data['trmnl']['device']['width']).to eq(1024)
+        expect(data['trmnl']['device']['height']).to eq(600)
+      end
+    end
+
+    context 'with only width provided' do
+      it 'uses the provided width and default height' do
+        data = context.user_data(device_width: 1024)
+        expect(data['trmnl']['device']['width']).to eq(1024)
+        expect(data['trmnl']['device']['height']).to eq(480)
+      end
+    end
+
+    context 'with only height provided' do
+      it 'uses the default width and provided height' do
+        data = context.user_data(device_height: 600)
+        expect(data['trmnl']['device']['width']).to eq(800)
+        expect(data['trmnl']['device']['height']).to eq(600)
+      end
+    end
+  end
+
   TEST_RESPONSES = [
     {
       header: 'application/json; charset=utf-8',

--- a/web/public/index.js
+++ b/web/public/index.js
@@ -12,8 +12,7 @@ trmnlp.connectLiveRender = function () {
 
     if (payload.type === "reload") {
       trmnlp.fetchPreview();
-      trmnlp.userData.textContent = JSON.stringify(payload.user_data, null, 2);
-      hljs.highlightAll();
+      trmnlp.fetchUserData();
     }
   };
 
@@ -21,6 +20,20 @@ trmnlp.connectLiveRender = function () {
     console.log("Reconnecting to live reload socket...");
     setTimeout(trmnlp.connectLiveRender, 1000);
   };
+};
+
+
+trmnlp.fetchUserData = function (pickerState) {
+  const state = pickerState || trmnlp.picker.state;
+  const width = encodeURIComponent(state.width);
+  const height = encodeURIComponent(state.height);
+
+  fetch(`/data?device_width=${width}&device_height=${height}`)
+    .then(response => response.text())
+    .then(json => {
+      trmnlp.userData.textContent = json;
+      hljs.highlightAll();
+    });
 };
 
 
@@ -77,6 +90,7 @@ document.addEventListener("DOMContentLoaded", async function () {
     trmnlp.iframe.style.height = `${event.detail.height}px`;
 
     trmnlp.fetchPreview(event.detail);
+    trmnlp.fetchUserData(event.detail);
   });
 
   trmnlp.picker = await TRMNLPicker.create('picker-form', { localStorageKey: 'trmnlp-picker' });


### PR DESCRIPTION
## Summary

Fixes #94 — device `width` and `height` in the user-data JSON were hardcoded to 800×480 and did not update when switching device models in the picker.

## Changes

- **`lib/trmnlp/context.rb`**: `user_data` and `base_trmnl_data` now accept optional `device_width:` and `device_height:` keyword arguments (defaulting to 800/480 for backward compatibility)
- **`lib/trmnlp/app.rb`**: The `GET /data` endpoint parses `device_width` and `device_height` query params and passes them to `Context#user_data`
- **`web/public/index.js`**: Added `trmnlp.fetchUserData()` which fetches `/data` with the current picker dimensions. Called on picker model change and on live reload events
- **`spec/lib/trmnlp/context_spec.rb`**: Added 4 tests covering default dimensions, custom dimensions, and partial overrides

## How it works

1. When the user changes the device model in the picker, the `trmnl:change` event fires
2. The frontend calls `fetchUserData(event.detail)` which sends `GET /data?device_width=W&device_height=H`
3. The server builds the user-data JSON with the requested dimensions instead of hardcoded values
4. The updated JSON is displayed in the preview panel

## Testing

```
bundle exec rake
# 4 new passing tests for #user_data dimension handling
```