### PR TITLE
Resolve post-0.8.0 issue queue and add coverage tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 
 # Changelog
 
+## 0.8.1
+
+### Added
+
+- `trmnlp build --png` renders a PNG for every view alongside the HTML, with `--width`, `--height`, and `--color-depth` flags to override the defaults (#92)
+- Colour-coded the preview's payload-size badge — yellow from 75 KB, red from 100 KB — so an oversized merge-variable payload is visible at a glance (#67)
+- Added colour to CLI output — `lint` results, warnings, and errors — suppressed automatically when output is piped or redirected (#33)
+
+### Fixed
+
+- `trmnlp init` no longer produces read-only project files when trmnlp itself is installed read-only, such as on NixOS (#83)
+- Non-JSON polling responses (`text/html`, `text/plain`) are exposed to templates as `{{ data }}`, matching the hosted service — previously `{{ text }}` (#81)
+
+### Housekeeping
+
+- Added SimpleCov coverage tracking, gated in CI at a 90% floor, plus dedicated specs for every lint check
+- Extracted the headless-Firefox driver into a shared `FirefoxDriver` module used by both `serve` and `build --png`
+
 ## 0.8.0
 
 ### Housekeeping

--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,6 @@ gem 'rack-test', '~> 2.1'
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.13'
 gem 'rubocop', require: false
+gem 'simplecov', '~> 0.22', require: false
 
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,6 @@ PATH
       selenium-webdriver (~> 4.44)
       sinatra (~> 4.1)
       thor (~> 1.3)
-      tone (~> 3.2)
       trmnl-liquid (~> 0.7.0)
       tzinfo-data (~> 1.2025)
       xdg (~> 10.2)
@@ -105,7 +104,6 @@ GEM
     rainbow (3.1.1)
     rake (13.4.2)
     redcarpet (3.6.1)
-    refinements (14.3.0)
     regexp_parser (2.12.0)
     rexml (3.4.4)
     rqrcode (3.2.0)
@@ -164,9 +162,6 @@ GEM
     strscan (3.1.8)
     thor (1.5.0)
     tilt (2.7.0)
-    tone (3.2.0)
-      refinements (~> 14.0)
-      zeitwerk (~> 2.7)
     trmnl-liquid (0.7.0)
       liquid (~> 5.12)
       redcarpet (~> 3.6)
@@ -182,7 +177,6 @@ GEM
     uri (1.1.1)
     websocket (1.2.11)
     xdg (10.2.0)
-    zeitwerk (2.8.0)
 
 PLATFORMS
   arm64-darwin-24

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trmnl_preview (0.8.0)
+    trmnl_preview (0.8.1)
       activesupport (~> 8.0)
       cgi (~> 0.5)
       faraday (~> 2.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,7 @@ PATH
       selenium-webdriver (~> 4.44)
       sinatra (~> 4.1)
       thor (~> 1.3)
+      tone (~> 3.2)
       trmnl-liquid (~> 0.7.0)
       tzinfo-data (~> 1.2025)
       xdg (~> 10.2)
@@ -103,6 +104,7 @@ GEM
     rainbow (3.1.1)
     rake (13.4.2)
     redcarpet (3.6.1)
+    refinements (14.3.0)
     regexp_parser (2.12.0)
     rexml (3.4.4)
     rqrcode (3.2.0)
@@ -155,6 +157,9 @@ GEM
     strscan (3.1.8)
     thor (1.5.0)
     tilt (2.7.0)
+    tone (3.2.0)
+      refinements (~> 14.0)
+      zeitwerk (~> 2.7)
     trmnl-liquid (0.7.0)
       liquid (~> 5.12)
       redcarpet (~> 3.6)
@@ -170,6 +175,7 @@ GEM
     uri (1.1.1)
     websocket (1.2.11)
     xdg (10.2.0)
+    zeitwerk (2.8.0)
 
 PLATFORMS
   arm64-darwin-24

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,7 @@ GEM
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     diff-lcs (1.6.2)
+    docile (1.4.1)
     drb (2.2.3)
     faraday (2.14.2)
       faraday-net_http (>= 2.0, < 3.5)
@@ -147,6 +148,12 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.2)
+    simplecov_json_formatter (0.1.4)
     sinatra (4.2.1)
       logger (>= 1.6.0)
       mustermann (~> 3.0)
@@ -187,6 +194,7 @@ DEPENDENCIES
   rake (~> 13.0)
   rspec (~> 3.13)
   rubocop
+  simplecov (~> 0.22)
   trmnl_preview!
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ trmnlp push                    # upload
 |---|---|
 | `trmnlp init NAME` | Start a new plugin project |
 | `trmnlp serve` | Start a local dev server |
-| `trmnlp build` | Generate static HTML files |
+| `trmnlp build` | Generate static HTML files, or PNGs with `--png` |
 | `trmnlp lint` | Check plugin code against TRMNL best practices |
 | `trmnlp login` | Authenticate with TRMNL server |
 | `trmnlp list` | List private plugins from TRMNL server |
@@ -90,6 +90,30 @@ trmnlp push                    # upload
 | `trmnlp version` | Show version |
 
 `trmnlp lint` exits non-zero when it finds issues, so you can gate CI on it. Run `trmnlp help` for all flags.
+
+## Building Static Files
+
+`trmnlp build` renders every view to a static file under `_build/` — handy for exporting a snapshot or feeding the output into another pipeline. Run it from inside a plugin project:
+
+```sh
+trmnlp build        # writes _build/full.html, _build/half_horizontal.html, ...
+trmnlp build --png  # also writes a PNG for each view
+```
+
+`--png` renders each view through the same screenshot pipeline `serve` uses. By default a PNG is 800×480 at the bit depth declared by the markup's `screen--Nbit` class (1-bit if none). Override any of those:
+
+```sh
+trmnlp build --png --color-depth 2
+```
+
+| Flag | Purpose |
+|---|---|
+| `--png` | Render a PNG per view alongside the HTML |
+| `--width` | PNG width in pixels (default 800) |
+| `--height` | PNG height in pixels (default 480) |
+| `--color-depth` | PNG bit depth — 1, 2, or 4 — overriding the markup |
+
+`--width`, `--height`, and `--color-depth` apply only with `--png`. PNG rendering needs Firefox and ImageMagick installed; plain `trmnlp build` needs neither.
 
 ## Authentication
 
@@ -309,6 +333,8 @@ To test, run:
 ```sh
 bin/rake
 ```
+
+Specs run under SimpleCov; a coverage report is written to `coverage/`.
 
 ## Contributing
 

--- a/bin/trmnlp
+++ b/bin/trmnlp
@@ -11,7 +11,8 @@ ENV['TZ'] = 'UTC'
 begin
   TRMNLP::CLI.start
 rescue TRMNLP::Error => e
-  puts "Error: #{e.message}"
+  reporter = TRMNLP::Reporter.new
+  reporter.info reporter.red("Error: #{e.message}")
   exit 1
 rescue Interrupt
   exit 1

--- a/lib/trmnlp/app.rb
+++ b/lib/trmnlp/app.rb
@@ -18,6 +18,16 @@ module TRMNLP
         bytes < 1024 ? "#{bytes} bytes" : format('%.1f KB', bytes / 1024.0)
       end
 
+      # Colour-codes the payload badge so an author notices when merge
+      # variables approach the size the hosted service starts rejecting.
+      # KB = 1024, matching format_bytes.
+      def payload_size_class(bytes)
+        return 'payload-size--over' if bytes >= 100 * 1024
+        return 'payload-size--warn' if bytes >= 75 * 1024
+
+        'payload-size--ok'
+      end
+
       # NOTE: render_html.erb's layout yields raw plugin HTML through `<%= yield %>`,
       # so a global `escape_html` setting would corrupt the render. Escape per-value.
       def h(text)

--- a/lib/trmnlp/cli.rb
+++ b/lib/trmnlp/cli.rb
@@ -19,6 +19,7 @@ module TRMNLP
     def self.default_bind = File.exist?('/.dockerenv') ? '0.0.0.0' : '127.0.0.1'
 
     desc 'build', 'Generate static HTML files'
+    method_option :png, type: :boolean, default: false, desc: 'Also render a PNG per view'
     def build
       Commands::Build.run(options)
     end

--- a/lib/trmnlp/cli.rb
+++ b/lib/trmnlp/cli.rb
@@ -20,6 +20,9 @@ module TRMNLP
 
     desc 'build', 'Generate static HTML files'
     method_option :png, type: :boolean, default: false, desc: 'Also render a PNG per view'
+    method_option :width, type: :numeric, desc: 'PNG width in pixels (with --png)'
+    method_option :height, type: :numeric, desc: 'PNG height in pixels (with --png)'
+    method_option :color_depth, type: :numeric, desc: 'PNG bit depth: 1, 2, or 4 (with --png)'
     def build
       Commands::Build.run(options)
     end

--- a/lib/trmnlp/commands/base.rb
+++ b/lib/trmnlp/commands/base.rb
@@ -50,7 +50,7 @@ module TRMNLP
       # plugin author notices before the field misbehaves in production.
       def report_form_field_warnings
         FormField.validate_all(config.plugin.custom_field_definitions).each do |warning|
-          reporter.info("warning: settings.yml custom_fields — #{warning}")
+          reporter.info(reporter.yellow("warning: settings.yml custom_fields — #{warning}"))
         end
       end
 

--- a/lib/trmnlp/commands/build.rb
+++ b/lib/trmnlp/commands/build.rb
@@ -11,7 +11,7 @@ require_relative '../screenshot'
 module TRMNLP
   module Commands
     class Build < Base
-      Options = Data.define(:dir, :quiet, :png)
+      Options = Data.define(:dir, :quiet, :png, :width, :height, :color_depth)
 
       def call
         context.validate!
@@ -45,10 +45,17 @@ module TRMNLP
       def write_png(view, html)
         path = context.paths.build_dir.join("#{view}.png")
         reporter.info "Writing #{path}..."
-        image = ScreenGenerator.new(html, screenshot:).process
+        image = screen_generator(html).process
         FileUtils.cp(image.path, path)
       ensure
         image&.close!
+      end
+
+      # --width/--height/--color-depth are optional; nil lets ScreenGenerator
+      # fall back to 800x480 and the screen--Nbit depth sniffed from the markup.
+      def screen_generator(html)
+        ScreenGenerator.new(html, screenshot:, width: options.width,
+                                  height: options.height, color_depth: options.color_depth)
       end
 
       def screenshot = @screenshot ||= Screenshot.new(pool: browser_pool)

--- a/lib/trmnlp/commands/build.rb
+++ b/lib/trmnlp/commands/build.rb
@@ -1,11 +1,17 @@
 # frozen_string_literal: true
 
+require 'fileutils'
+
 require_relative 'base'
+require_relative '../browser_pool'
+require_relative '../firefox_driver'
+require_relative '../screen_generator'
+require_relative '../screenshot'
 
 module TRMNLP
   module Commands
     class Build < Base
-      Options = Data.define(:dir, :quiet)
+      Options = Data.define(:dir, :quiet, :png)
 
       def call
         context.validate!
@@ -13,13 +19,42 @@ module TRMNLP
         context.poller.poll_data
         context.paths.create_build_dir
 
-        Screen.all.each do |screen|
-          output_path = context.paths.build_dir.join("#{screen.name}.html")
-          reporter.info "Writing #{output_path}..."
-          output_path.write(context.renderer.render_full_page(screen.name))
-        end
+        Screen.all.each { |screen| build_screen(screen) }
 
         reporter.info 'Done!'
+      ensure
+        @browser_pool&.shutdown
+      end
+
+      private
+
+      def build_screen(screen)
+        html = context.renderer.render_full_page(screen.name)
+        write_html(screen.name, html)
+        write_png(screen.name, html) if options.png
+      end
+
+      def write_html(view, html)
+        path = context.paths.build_dir.join("#{view}.html")
+        reporter.info "Writing #{path}..."
+        path.write(html)
+      end
+
+      # --png is additive: the HTML is rendered either way, so it stays on
+      # disk alongside the PNG rather than being replaced by it.
+      def write_png(view, html)
+        path = context.paths.build_dir.join("#{view}.png")
+        reporter.info "Writing #{path}..."
+        image = ScreenGenerator.new(html, screenshot:).process
+        FileUtils.cp(image.path, path)
+      ensure
+        image&.close!
+      end
+
+      def screenshot = @screenshot ||= Screenshot.new(pool: browser_pool)
+
+      def browser_pool
+        @browser_pool ||= BrowserPool.new(driver_factory: FirefoxDriver.method(:build))
       end
     end
   end

--- a/lib/trmnlp/commands/init.rb
+++ b/lib/trmnlp/commands/init.rb
@@ -35,6 +35,10 @@ module TRMNLP
 
           reporter.info "Creating #{destination_pathname}"
           FileUtils.cp(source_pathname, destination_pathname)
+          # NOTE: cp preserves the source mode. Templates installed read-only
+          # (e.g. NixOS /nix/store is 0444) would leave the author unable to
+          # edit their own project. Add owner-write; keep any exec bit.
+          destination_pathname.chmod(destination_pathname.stat.mode | 0o200)
         end
 
         reporter.info <<~HEREDOC

--- a/lib/trmnlp/commands/serve.rb
+++ b/lib/trmnlp/commands/serve.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
-require 'selenium-webdriver'
-
 require_relative 'base'
 require_relative '../api_client'
 require_relative '../browser_pool'
+require_relative '../firefox_driver'
 
 module TRMNLP
   module Commands
@@ -20,7 +19,7 @@ module TRMNLP
 
         # Now we can configure things
         App.set(:context, context)
-        App.set(:browser_pool, BrowserPool.new(driver_factory: method(:build_firefox_driver)))
+        App.set(:browser_pool, BrowserPool.new(driver_factory: FirefoxDriver.method(:build)))
         App.set(:bind, options.bind)
         App.set(:port, options.port)
         permit_all_hosts if codespaces?
@@ -36,18 +35,6 @@ module TRMNLP
 
       def permit_all_hosts
         App.set(:host_authorization, { allow_if: ->(_env) { true } })
-      end
-
-      def build_firefox_driver
-        options = Selenium::WebDriver::Firefox::Options.new
-        options.add_argument('--headless')
-        options.add_argument('--disable-web-security')
-        # Disable subpixel antialiasing — its colour fringing quantizes badly on 1-bit e-ink.
-        options.add_preference('gfx.text.disable-aa', true)
-        options.add_preference('gfx.text.subpixel-position.force-disabled', true)
-        Selenium::WebDriver.for(:firefox, options: options).tap do |driver|
-          driver.manage.window.maximize
-        end
       end
     end
   end

--- a/lib/trmnlp/firefox_driver.rb
+++ b/lib/trmnlp/firefox_driver.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'selenium-webdriver'
+
+module TRMNLP
+  # Builds the headless Firefox driver that screenshots rendered plugins.
+  # Shared by `trmnlp serve` (the PNG preview route) and `trmnlp build --png`.
+  module FirefoxDriver
+    module_function
+
+    def build
+      Selenium::WebDriver.for(:firefox, options:).tap do |driver|
+        driver.manage.window.maximize
+      end
+    end
+
+    def options
+      Selenium::WebDriver::Firefox::Options.new.tap do |opts|
+        opts.add_argument('--headless')
+        opts.add_argument('--disable-web-security')
+        # Subpixel antialiasing colour-fringes badly when quantized to 1-bit e-ink.
+        opts.add_preference('gfx.text.disable-aa', true)
+        opts.add_preference('gfx.text.subpixel-position.force-disabled', true)
+      end
+    end
+  end
+end

--- a/lib/trmnlp/poller.rb
+++ b/lib/trmnlp/poller.rb
@@ -76,7 +76,7 @@ module TRMNLP
       case content_type
       when 'application/json', %r{^application/.+\+json} then wrap_array(JSON.parse(body))
       when 'text/xml', 'application/xml', %r{^application/.+\+xml} then wrap_array(Hash.from_xml(body))
-      when 'text/html', 'text/plain' then sniff_json(body) || { 'text' => body }
+      when 'text/html', 'text/plain' then sniff_json(body) || { 'data' => body }
       else log_unknown_type(content_type_header)
       end
     end

--- a/lib/trmnlp/poller.rb
+++ b/lib/trmnlp/poller.rb
@@ -25,7 +25,7 @@ module TRMNLP
     # and keep the preview server alive, not crash the user's session. We
     # deliberately swallow here and return {} so the renderer keeps rendering.
     rescue StandardError => e
-      reporter.info("warning: #{e.message}")
+      reporter.info(reporter.yellow("warning: #{e.message}"))
       {}
     end
 
@@ -34,7 +34,7 @@ module TRMNLP
     # NOTE: Same rationale as #poll_data — a bad webhook payload shouldn't take
     # down the dev server. Report a warning and keep serving.
     rescue StandardError => e
-      reporter.info("webhook warning: #{e.message}")
+      reporter.info(reporter.yellow("webhook warning: #{e.message}"))
     end
 
     private

--- a/lib/trmnlp/reporter.rb
+++ b/lib/trmnlp/reporter.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'tone'
+
 module TRMNLP
   # Single sink for user-facing command output. Records every message so
   # specs can assert on what a command would have said, and writes to the
@@ -11,6 +13,9 @@ module TRMNLP
       @quiet = quiet
       @stream = stream
       @messages = []
+      # Colour only when the stream is a real terminal, so ANSI codes
+      # never leak into piped or redirected output.
+      @tone = Tone.new(enabled: stream.tty?)
     end
 
     def info(message)
@@ -18,11 +23,12 @@ module TRMNLP
       @stream.puts(message) unless @quiet
     end
 
-    def green(text) = colorize(text, 32)
-    def yellow(text) = colorize(text, 33)
+    def green(text) = tone[text, :green]
+    def yellow(text) = tone[text, :yellow]
+    def red(text) = tone[text, :red]
 
     private
 
-    def colorize(text, code) = "\e[#{code}m#{text}\e[0m"
+    attr_reader :tone
   end
 end

--- a/lib/trmnlp/reporter.rb
+++ b/lib/trmnlp/reporter.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'tone'
-
 module TRMNLP
   # Single sink for user-facing command output. Records every message so
   # specs can assert on what a command would have said, and writes to the
@@ -15,7 +13,7 @@ module TRMNLP
       @messages = []
       # Colour only when the stream is a real terminal, so ANSI codes
       # never leak into piped or redirected output.
-      @tone = Tone.new(enabled: stream.tty?)
+      @tty = stream.tty?
     end
 
     def info(message)
@@ -23,12 +21,12 @@ module TRMNLP
       @stream.puts(message) unless @quiet
     end
 
-    def green(text) = tone[text, :green]
-    def yellow(text) = tone[text, :yellow]
-    def red(text) = tone[text, :red]
+    def green(text) = colorize(text, 32)
+    def yellow(text) = colorize(text, 33)
+    def red(text) = colorize(text, 31)
 
     private
 
-    attr_reader :tone
+    def colorize(text, code) = @tty ? "\e[#{code}m#{text}\e[0m" : text
   end
 end

--- a/lib/trmnlp/screenshot.rb
+++ b/lib/trmnlp/screenshot.rb
@@ -3,10 +3,13 @@
 require 'selenium-webdriver'
 require 'tempfile'
 
+require_relative 'errors'
+
 module TRMNLP
   class Screenshot
-    def initialize(pool:)
+    def initialize(pool:, viewport_timeout: 5)
       @pool = pool
+      @viewport_timeout = viewport_timeout
     end
 
     def call(html:, width:, height:)
@@ -50,15 +53,25 @@ module TRMNLP
     # NOTE: A cold Firefox — e.g. the first render after the container boots —
     # applies a window resize lazily. The old fixed sleep raced that reflow and
     # clipped the first screenshot short (800x433 instead of 800x480). Poll the
-    # real viewport instead, re-applying the size until it lands; a resize that
-    # never settles surfaces as a TimeoutError that #call already retries.
+    # real viewport instead, re-applying the size until it lands. A width the
+    # browser refuses to honour (below its ~500px window minimum) never settles;
+    # that surfaces as a clear RenderError rather than an opaque, retried timeout.
     def wait_for_viewport(driver, width, height)
-      Selenium::WebDriver::Wait.new(timeout: 5, interval: 0.1).until do
+      Selenium::WebDriver::Wait.new(timeout: @viewport_timeout, interval: 0.1).until do
         next true if viewport(driver) == [width, height]
 
         apply_window_size(driver, width, height)
         false
       end
+    rescue Selenium::WebDriver::Error::TimeoutError
+      raise RenderError, viewport_clamp_message(driver, width, height)
+    end
+
+    def viewport_clamp_message(driver, width, height)
+      actual_width, actual_height = viewport(driver)
+      "Could not render at #{width}x#{height}: the browser clamped the viewport " \
+        "to #{actual_width}x#{actual_height}. PNG rendering needs a width of " \
+        'roughly 500px or more — headless Firefox will not size its window narrower.'
     end
 
     def viewport(driver)

--- a/lib/trmnlp/version.rb
+++ b/lib/trmnlp/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TRMNLP
-  VERSION = '0.8.0'
+  VERSION = '0.8.1'
 end

--- a/spec/lib/trmnlp/app_spec.rb
+++ b/spec/lib/trmnlp/app_spec.rb
@@ -95,6 +95,32 @@ RSpec.describe TRMNLP::App do
     end
   end
 
+  describe 'GET /:view payload-size badge (#67)' do
+    it 'marks a payload under 75 KB green' do
+      allow(context.user_data_assembler).to receive(:call).and_return({ 'k' => 'small' })
+
+      get '/full'
+
+      expect(last_response.body).to include('payload-size payload-size--ok')
+    end
+
+    it 'marks a payload between 75 and 100 KB yellow' do
+      allow(context.user_data_assembler).to receive(:call).and_return({ 'k' => 'a' * 90_000 })
+
+      get '/full'
+
+      expect(last_response.body).to include('payload-size payload-size--warn')
+    end
+
+    it 'marks a payload at or above 100 KB red' do
+      allow(context.user_data_assembler).to receive(:call).and_return({ 'k' => 'a' * 110_000 })
+
+      get '/full'
+
+      expect(last_response.body).to include('payload-size payload-size--over')
+    end
+  end
+
   describe 'GET /poll' do
     it 'triggers a poll and redirects back' do
       get '/poll', {}, { 'HTTP_REFERER' => '/full' }

--- a/spec/lib/trmnlp/commands/build_spec.rb
+++ b/spec/lib/trmnlp/commands/build_spec.rb
@@ -6,15 +6,15 @@ require 'tmpdir'
 require 'trmnlp/commands/build'
 
 RSpec.describe TRMNLP::Commands::Build do
-  subject(:command) do
-    described_class.new(context:,
-                        options: described_class::Options.new(dir: tmp_root, quiet: true, png: false),
-                        reporter:)
-  end
+  subject(:command) { described_class.new(context:, options:, reporter:) }
 
   let(:tmp_root) { Dir.mktmpdir('trmnlp-build-') }
   let(:context) { TRMNLP::Context.new(tmp_root) }
   let(:reporter) { TRMNLP::Reporter.new(quiet: true) }
+  let(:options) do
+    described_class::Options.new(dir: tmp_root, quiet: true, png: false,
+                                 width: nil, height: nil, color_depth: nil)
+  end
 
   before do
     File.write(File.join(tmp_root, '.trmnlp.yml'), '---')
@@ -59,9 +59,9 @@ RSpec.describe TRMNLP::Commands::Build do
 
     it 'raises when the project is not a trmnlp directory' do
       bad_root = Dir.mktmpdir('trmnlp-build-bad-')
-      cmd = described_class.new(context: TRMNLP::Context.new(bad_root),
-                                options: described_class::Options.new(dir: bad_root,
-                                                                      quiet: true, png: false))
+      bad_options = described_class::Options.new(dir: bad_root, quiet: true, png: false,
+                                                 width: nil, height: nil, color_depth: nil)
+      cmd = described_class.new(context: TRMNLP::Context.new(bad_root), options: bad_options)
 
       expect { cmd.call }.to raise_error(TRMNLP::NotAPlugin)
     ensure
@@ -69,12 +69,10 @@ RSpec.describe TRMNLP::Commands::Build do
     end
 
     context 'with --png (#92)' do
-      subject(:command) do
-        described_class.new(context:,
-                            options: described_class::Options.new(dir: tmp_root, quiet: true, png: true),
-                            reporter:)
+      let(:options) do
+        described_class::Options.new(dir: tmp_root, quiet: true, png: true,
+                                     width: nil, height: nil, color_depth: nil)
       end
-
       let(:screen_generator) { instance_double(TRMNLP::ScreenGenerator) }
 
       before do
@@ -104,7 +102,17 @@ RSpec.describe TRMNLP::Commands::Build do
       it 'screenshots the rendered markup for each view' do
         command.call
 
-        expect(TRMNLP::ScreenGenerator).to have_received(:new).with('<html>full</html>', screenshot: anything)
+        expect(TRMNLP::ScreenGenerator).to have_received(:new).with('<html>full</html>', anything)
+      end
+
+      it 'passes the width, height and colour depth to the screen generator' do
+        sized = described_class::Options.new(dir: tmp_root, quiet: true, png: true,
+                                             width: 400, height: 200, color_depth: 2)
+        described_class.new(context:, options: sized, reporter:).call
+
+        expect(TRMNLP::ScreenGenerator).to have_received(:new).with(
+          '<html>full</html>', hash_including(width: 400, height: 200, color_depth: 2)
+        )
       end
     end
   end

--- a/spec/lib/trmnlp/commands/build_spec.rb
+++ b/spec/lib/trmnlp/commands/build_spec.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'tempfile'
 require 'tmpdir'
 require 'trmnlp/commands/build'
 
 RSpec.describe TRMNLP::Commands::Build do
   subject(:command) do
-    described_class.new(context:, options: described_class::Options.new(dir: tmp_root, quiet: true), reporter:)
+    described_class.new(context:,
+                        options: described_class::Options.new(dir: tmp_root, quiet: true, png: false),
+                        reporter:)
   end
 
   let(:tmp_root) { Dir.mktmpdir('trmnlp-build-') }
@@ -58,11 +61,51 @@ RSpec.describe TRMNLP::Commands::Build do
       bad_root = Dir.mktmpdir('trmnlp-build-bad-')
       cmd = described_class.new(context: TRMNLP::Context.new(bad_root),
                                 options: described_class::Options.new(dir: bad_root,
-                                                                      quiet: true))
+                                                                      quiet: true, png: false))
 
       expect { cmd.call }.to raise_error(TRMNLP::NotAPlugin)
     ensure
       FileUtils.rm_rf(bad_root)
+    end
+
+    context 'with --png (#92)' do
+      subject(:command) do
+        described_class.new(context:,
+                            options: described_class::Options.new(dir: tmp_root, quiet: true, png: true),
+                            reporter:)
+      end
+
+      let(:screen_generator) { instance_double(TRMNLP::ScreenGenerator) }
+
+      before do
+        allow(TRMNLP::ScreenGenerator).to receive(:new).and_return(screen_generator)
+        allow(screen_generator).to receive(:process) do
+          file = Tempfile.new(['screenshot', '.png'])
+          file.write('fake-png')
+          file.close
+          file
+        end
+      end
+
+      it 'writes a PNG for every view' do
+        command.call
+
+        written = Dir[File.join(tmp_root, '_build', '*.png')].map { |path| File.basename(path, '.png') }
+        expect(written).to contain_exactly(*TRMNLP::Screen.names)
+      end
+
+      it 'still writes the HTML files' do
+        command.call
+
+        written = Dir[File.join(tmp_root, '_build', '*.html')].map { |path| File.basename(path, '.html') }
+        expect(written).to contain_exactly(*TRMNLP::Screen.names)
+      end
+
+      it 'screenshots the rendered markup for each view' do
+        command.call
+
+        expect(TRMNLP::ScreenGenerator).to have_received(:new).with('<html>full</html>', screenshot: anything)
+      end
     end
   end
 end

--- a/spec/lib/trmnlp/commands/init_spec.rb
+++ b/spec/lib/trmnlp/commands/init_spec.rb
@@ -35,5 +35,37 @@ RSpec.describe TRMNLP::Commands::Init do
       expect(File).to exist(File.join(project, 'src', 'settings.yml'))
       expect(File).not_to exist(File.join(project, 'src', 'full.liquid'))
     end
+
+    context 'when the template source is read-only (#83)' do
+      let(:templates_dir) { Pathname.new(Dir.mktmpdir('trmnlp-templates-')) }
+      let(:read_only_file) { templates_dir.join('init', 'src', 'settings.yml') }
+      let(:read_only_executable) { templates_dir.join('init', 'bin', 'trmnlp') }
+
+      before do
+        read_only_file.dirname.mkpath
+        read_only_file.write("---\nname: demo\n")
+        read_only_file.chmod(0o444)
+
+        read_only_executable.dirname.mkpath
+        read_only_executable.write("#!/usr/bin/env ruby\n")
+        read_only_executable.chmod(0o555)
+
+        allow(context.paths).to receive(:templates_dir).and_return(templates_dir)
+      end
+
+      after { FileUtils.rm_rf(templates_dir) }
+
+      it 'makes copied files owner-writable' do
+        command.call('demo')
+
+        expect(Pathname.new(tmp_root).join('demo/src/settings.yml').stat.mode & 0o200).to eq(0o200)
+      end
+
+      it 'preserves the executable bit on copied files' do
+        command.call('demo')
+
+        expect(Pathname.new(tmp_root).join('demo/bin/trmnlp').stat.mode & 0o100).to eq(0o100)
+      end
+    end
   end
 end

--- a/spec/lib/trmnlp/firefox_driver_spec.rb
+++ b/spec/lib/trmnlp/firefox_driver_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'trmnlp/firefox_driver'
+
+RSpec.describe TRMNLP::FirefoxDriver do
+  describe '.options' do
+    subject(:options) { described_class.options }
+
+    it 'runs Firefox headless with web security disabled' do
+      expect(options.args).to include('--headless', '--disable-web-security')
+    end
+
+    it 'disables subpixel antialiasing so 1-bit quantization stays clean' do
+      expect(options.prefs).to include('gfx.text.disable-aa' => true,
+                                       'gfx.text.subpixel-position.force-disabled' => true)
+    end
+  end
+end

--- a/spec/lib/trmnlp/lint/checks/custom_fields_used_spec.rb
+++ b/spec/lib/trmnlp/lint/checks/custom_fields_used_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'trmnlp/lint/source'
+require 'trmnlp/lint/checks/custom_fields_used'
+
+RSpec.describe TRMNLP::Lint::Checks::CustomFieldsUsed do
+  subject(:check) { described_class.new(source) }
+
+  let(:source) do
+    instance_double(TRMNLP::Lint::Source, custom_field_values: field_values, settings: {}, all_markup: markup)
+  end
+
+  describe '#issues' do
+    context 'when a custom field never appears in the markup or settings' do
+      let(:field_values) { { 'ghost' => 'value' } }
+      let(:markup) { '<p>unrelated content</p>' }
+
+      it 'reports the unused field' do
+        expect(check.issues).not_to be_empty
+      end
+    end
+
+    context 'when a custom field is referenced in the markup' do
+      let(:field_values) { { 'headline' => 'value' } }
+      let(:markup) { '<p>{{ headline }}</p>' }
+
+      it 'passes' do
+        expect(check.issues).to be_empty
+      end
+    end
+  end
+end

--- a/spec/lib/trmnlp/lint/checks/form_fields_valid_spec.rb
+++ b/spec/lib/trmnlp/lint/checks/form_fields_valid_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'trmnlp/lint/source'
+require 'trmnlp/lint/checks/form_fields_valid'
+
+RSpec.describe TRMNLP::Lint::Checks::FormFieldsValid do
+  subject(:check) { described_class.new(source) }
+
+  let(:source) { instance_double(TRMNLP::Lint::Source, custom_field_definitions: definitions) }
+
+  describe '#issues' do
+    context 'when a custom field definition is missing required keys' do
+      let(:definitions) { [{ 'keyname' => 'broken' }] }
+
+      it 'reports the issue' do
+        expect(check.issues).not_to be_empty
+      end
+    end
+
+    context 'when there are no custom field definitions' do
+      let(:definitions) { [] }
+
+      it 'passes' do
+        expect(check.issues).to be_empty
+      end
+    end
+  end
+end

--- a/spec/lib/trmnlp/lint/checks/highcharts_animations_disabled_spec.rb
+++ b/spec/lib/trmnlp/lint/checks/highcharts_animations_disabled_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'trmnlp/lint/source'
+require 'trmnlp/lint/checks/highcharts_animations_disabled'
+
+RSpec.describe TRMNLP::Lint::Checks::HighchartsAnimationsDisabled do
+  subject(:check) { described_class.new(source) }
+
+  let(:source) { instance_double(TRMNLP::Lint::Source, all_markup: markup) }
+
+  describe '#issues' do
+    context 'when Highcharts is used without disabling animation' do
+      let(:markup) { '<div id="highcharts">chart</div>' }
+
+      it 'reports the issue' do
+        expect(check.issues).not_to be_empty
+      end
+    end
+
+    context 'when Highcharts disables animation' do
+      let(:markup) { '<div id="highcharts" data-config="animation: false">chart</div>' }
+
+      it 'passes' do
+        expect(check.issues).to be_empty
+      end
+    end
+  end
+end

--- a/spec/lib/trmnlp/lint/checks/highcharts_elements_unique_spec.rb
+++ b/spec/lib/trmnlp/lint/checks/highcharts_elements_unique_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'trmnlp/lint/source'
+require 'trmnlp/lint/checks/highcharts_elements_unique'
+
+RSpec.describe TRMNLP::Lint::Checks::HighchartsElementsUnique do
+  subject(:check) { described_class.new(source) }
+
+  let(:source) { instance_double(TRMNLP::Lint::Source, all_markup: markup) }
+
+  describe '#issues' do
+    context 'when Highcharts is used without the append_random filter' do
+      let(:markup) { '<div id="highcharts">chart</div>' }
+
+      it 'reports the issue' do
+        expect(check.issues).not_to be_empty
+      end
+    end
+
+    context 'when Highcharts elements use the append_random filter' do
+      let(:markup) { '<div id="{{ "highcharts" | append_random }}">chart</div>' }
+
+      it 'passes' do
+        expect(check.issues).to be_empty
+      end
+    end
+  end
+end

--- a/spec/lib/trmnlp/lint/checks/layouts_have_content_spec.rb
+++ b/spec/lib/trmnlp/lint/checks/layouts_have_content_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'trmnlp/lint/source'
+require 'trmnlp/lint/checks/layouts_have_content'
+
+RSpec.describe TRMNLP::Lint::Checks::LayoutsHaveContent do
+  subject(:check) { described_class.new(source) }
+
+  let(:source) { instance_double(TRMNLP::Lint::Source, view_markup: views, shared_markup: '') }
+
+  describe '#issues' do
+    context 'when a view and the shared markup are both empty' do
+      let(:views) { { 'full' => '' } }
+
+      it 'reports the issue' do
+        expect(check.issues).not_to be_empty
+      end
+    end
+
+    context 'when every view carries enough content' do
+      let(:views) { { 'full' => '<p>Real content here</p>' } }
+
+      it 'passes' do
+        expect(check.issues).to be_empty
+      end
+    end
+  end
+end

--- a/spec/lib/trmnlp/lint/checks/limited_inline_styles_spec.rb
+++ b/spec/lib/trmnlp/lint/checks/limited_inline_styles_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'trmnlp/lint/source'
+require 'trmnlp/lint/checks/limited_inline_styles'
+
+RSpec.describe TRMNLP::Lint::Checks::LimitedInlineStyles do
+  subject(:check) { described_class.new(source) }
+
+  let(:source) { instance_double(TRMNLP::Lint::Source, all_markup: markup) }
+
+  describe '#issues' do
+    context 'when the markup leans on more inline style properties than allowed' do
+      let(:markup) do
+        '<div style="padding:1px;margin:1px;font-size:1px;text-align:left;' \
+          'background-color:red;border-radius:1px;object-fit:cover">busy</div>'
+      end
+
+      it 'reports the issue' do
+        expect(check.issues).not_to be_empty
+      end
+    end
+
+    context 'when the markup uses few inline style properties' do
+      let(:markup) { '<div style="padding: 1em">tidy</div>' }
+
+      it 'passes' do
+        expect(check.issues).to be_empty
+      end
+    end
+  end
+end

--- a/spec/lib/trmnlp/lint/checks/no_async_functions_spec.rb
+++ b/spec/lib/trmnlp/lint/checks/no_async_functions_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'trmnlp/lint/source'
+require 'trmnlp/lint/checks/no_async_functions'
+
+RSpec.describe TRMNLP::Lint::Checks::NoAsyncFunctions do
+  subject(:check) { described_class.new(source) }
+
+  let(:source) { instance_double(TRMNLP::Lint::Source, all_markup: markup) }
+
+  describe '#issues' do
+    context 'when the markup defines an async function' do
+      let(:markup) { '<script>async function load() {}</script>' }
+
+      it 'reports the issue' do
+        expect(check.issues).not_to be_empty
+      end
+    end
+
+    context 'when the markup uses only synchronous functions' do
+      let(:markup) { '<script>function load() {}</script>' }
+
+      it 'passes' do
+        expect(check.issues).to be_empty
+      end
+    end
+  end
+end

--- a/spec/lib/trmnlp/lint/checks/no_size_classes_spec.rb
+++ b/spec/lib/trmnlp/lint/checks/no_size_classes_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'trmnlp/lint/source'
+require 'trmnlp/lint/checks/no_size_classes'
+
+RSpec.describe TRMNLP::Lint::Checks::NoSizeClasses do
+  subject(:check) { described_class.new(source) }
+
+  let(:source) { instance_double(TRMNLP::Lint::Source, all_markup: markup) }
+
+  describe '#issues' do
+    context 'when the markup re-applies a view size class' do
+      let(:markup) { '<div class="view--full">content</div>' }
+
+      it 'reports the issue' do
+        expect(check.issues).not_to be_empty
+      end
+    end
+
+    context 'when the markup uses its own classes' do
+      let(:markup) { '<div class="headline">content</div>' }
+
+      it 'passes' do
+        expect(check.issues).to be_empty
+      end
+    end
+  end
+end

--- a/spec/lib/trmnlp/lint/checks/title_casing_spec.rb
+++ b/spec/lib/trmnlp/lint/checks/title_casing_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'trmnlp/lint/source'
+require 'trmnlp/lint/checks/title_casing'
+
+RSpec.describe TRMNLP::Lint::Checks::TitleCasing do
+  subject(:check) { described_class.new(source) }
+
+  let(:source) { instance_double(TRMNLP::Lint::Source, plugin_name: name) }
+
+  describe '#issues' do
+    context 'when the plugin name starts with a lowercase letter' do
+      let(:name) { 'weather widget' }
+
+      it 'reports the issue' do
+        expect(check.issues).not_to be_empty
+      end
+    end
+
+    context 'when the plugin name starts with a capital letter' do
+      let(:name) { 'Weather Widget' }
+
+      it 'passes' do
+        expect(check.issues).to be_empty
+      end
+    end
+  end
+end

--- a/spec/lib/trmnlp/lint/checks/title_length_spec.rb
+++ b/spec/lib/trmnlp/lint/checks/title_length_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'trmnlp/lint/source'
+require 'trmnlp/lint/checks/title_length'
+
+RSpec.describe TRMNLP::Lint::Checks::TitleLength do
+  subject(:check) { described_class.new(source) }
+
+  let(:source) { instance_double(TRMNLP::Lint::Source, plugin_name: name) }
+
+  describe '#issues' do
+    context 'when the plugin name exceeds 50 characters' do
+      let(:name) { 'A' * 51 }
+
+      it 'reports the issue' do
+        expect(check.issues).not_to be_empty
+      end
+    end
+
+    context 'when the plugin name is within 50 characters' do
+      let(:name) { 'Weather Widget' }
+
+      it 'passes' do
+        expect(check.issues).to be_empty
+      end
+    end
+  end
+end

--- a/spec/lib/trmnlp/lint/checks/waits_for_dom_load_spec.rb
+++ b/spec/lib/trmnlp/lint/checks/waits_for_dom_load_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'trmnlp/lint/source'
+require 'trmnlp/lint/checks/waits_for_dom_load'
+
+RSpec.describe TRMNLP::Lint::Checks::WaitsForDomLoad do
+  subject(:check) { described_class.new(source) }
+
+  let(:source) { instance_double(TRMNLP::Lint::Source, all_markup: markup) }
+
+  describe '#issues' do
+    context 'when the markup hooks the window load event' do
+      let(:markup) { '<script>window.onload = init</script>' }
+
+      it 'reports the issue' do
+        expect(check.issues).not_to be_empty
+      end
+    end
+
+    context 'when the markup listens for DOMContentLoaded' do
+      let(:markup) { '<script>document.addEventListener("DOMContentLoaded", init)</script>' }
+
+      it 'passes' do
+        expect(check.issues).to be_empty
+      end
+    end
+  end
+end

--- a/spec/lib/trmnlp/poller_spec.rb
+++ b/spec/lib/trmnlp/poller_spec.rb
@@ -45,11 +45,11 @@ RSpec.describe TRMNLP::Poller do
       { name: 'html',
         header: 'text/html; charset=utf-8',
         body: '<html>not json</html>',
-        parsed: { 'text' => '<html>not json</html>' } },
+        parsed: { 'data' => '<html>not json</html>' } },
       { name: 'plain text',
         header: 'text/plain',
         body: 'hello world',
-        parsed: { 'text' => 'hello world' } }
+        parsed: { 'data' => 'hello world' } }
     ]
   end
   let(:expected_by_case) { content_type_cases.to_h { |test_case| [test_case[:name], test_case[:parsed]] } }

--- a/spec/lib/trmnlp/reporter_spec.rb
+++ b/spec/lib/trmnlp/reporter_spec.rb
@@ -34,4 +34,44 @@ RSpec.describe TRMNLP::Reporter do
       end
     end
   end
+
+  describe '#green' do
+    context 'when the stream is a terminal' do
+      subject(:reporter) { described_class.new(stream:) }
+
+      before { allow(stream).to receive(:tty?).and_return(true) }
+
+      it 'wraps the text in the green ANSI code' do
+        expect(reporter.green('ok')).to eq("\e[32mok\e[0m")
+      end
+    end
+
+    context 'when the stream is not a terminal' do
+      subject(:reporter) { described_class.new(stream:) }
+
+      it 'returns plain text so ANSI never leaks into redirected output' do
+        expect(reporter.green('ok')).to eq('ok')
+      end
+    end
+  end
+
+  describe '#yellow' do
+    subject(:reporter) { described_class.new(stream:) }
+
+    before { allow(stream).to receive(:tty?).and_return(true) }
+
+    it 'wraps the text in the yellow ANSI code' do
+      expect(reporter.yellow('hmm')).to eq("\e[33mhmm\e[0m")
+    end
+  end
+
+  describe '#red' do
+    subject(:reporter) { described_class.new(stream:) }
+
+    before { allow(stream).to receive(:tty?).and_return(true) }
+
+    it 'wraps the text in the red ANSI code' do
+      expect(reporter.red('no')).to eq("\e[31mno\e[0m")
+    end
+  end
 end

--- a/spec/lib/trmnlp/screenshot_spec.rb
+++ b/spec/lib/trmnlp/screenshot_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe TRMNLP::Screenshot do
 
   class FakeDriver
     attr_reader :scripts_run, :window_size, :screenshot_path, :navigated_to, :size_set_count
-    attr_accessor :script_errors, :viewport_overrides
+    attr_accessor :script_errors, :viewport_overrides, :min_window_width
 
     def initialize
       @scripts_run = []
@@ -19,6 +19,7 @@ RSpec.describe TRMNLP::Screenshot do
       @script_errors = []
       @viewport_overrides = []
       @size_set_count = 0
+      @min_window_width = nil
     end
 
     def execute_script(script, *_args)
@@ -46,11 +47,14 @@ RSpec.describe TRMNLP::Screenshot do
 
     # A real browser's viewport is the window minus the chrome borders
     # (10x20 above). Queue `viewport_overrides` to simulate a cold Firefox
-    # reporting a not-yet-settled size before the resize lands.
+    # reporting a not-yet-settled size before the resize lands. Set
+    # `min_window_width` to simulate Firefox refusing to shrink its window
+    # below a minimum (clamping the viewport wider than requested).
     def next_viewport
       return @viewport_overrides.shift if @viewport_overrides.any?
 
-      [@window_size.width - 10, @window_size.height - 20]
+      effective_width = [@window_size.width, @min_window_width || 0].max
+      [effective_width - 10, @window_size.height - 20]
     end
   end
 
@@ -110,6 +114,17 @@ RSpec.describe TRMNLP::Screenshot do
     it 'raises after two failed attempts' do
       pool.raise_on = Array.new(2) { Selenium::WebDriver::Error::WebDriverError.new('flake') }
       expect { result }.to raise_error(Selenium::WebDriver::Error::WebDriverError)
+    end
+
+    context 'when the browser clamps the window below the requested width' do
+      subject(:screenshot) { described_class.new(pool:, viewport_timeout: 0.1) }
+
+      before { driver.min_window_width = 510 }
+
+      it 'raises a RenderError naming the requested and clamped sizes' do
+        expect { screenshot.call(html: '<p>hi</p>', width: 400, height: 240) }
+          .to raise_error(TRMNLP::RenderError, /400x240.+500x240/)
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
+# Must load before any application code so every line is counted.
+require 'simplecov'
+
+SimpleCov.start do
+  add_filter '/spec/'
+  # Enforce the floor in CI only: a partial local run loads just a few
+  # files and would otherwise report a misleadingly low number. Ratchet
+  # this upward as coverage improves.
+  minimum_coverage 90 if ENV.fetch('CI', false) == 'true'
+end
+
 require File.join(__dir__, '../lib/trmnlp')
 
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration

--- a/trmnl_preview.gemspec
+++ b/trmnl_preview.gemspec
@@ -60,6 +60,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rexml', '~> 3.4'
   spec.add_dependency 'rubyzip', '~> 3.3'
   spec.add_dependency 'thor', '~> 1.3'
+  spec.add_dependency 'tone', '~> 3.2'
   spec.add_dependency 'tzinfo-data', '~> 1.2025'
   spec.add_dependency 'xdg', '~> 10.2'
 

--- a/trmnl_preview.gemspec
+++ b/trmnl_preview.gemspec
@@ -60,7 +60,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rexml', '~> 3.4'
   spec.add_dependency 'rubyzip', '~> 3.3'
   spec.add_dependency 'thor', '~> 1.3'
-  spec.add_dependency 'tone', '~> 3.2'
   spec.add_dependency 'tzinfo-data', '~> 1.2025'
   spec.add_dependency 'xdg', '~> 10.2'
 

--- a/web/public/index.css
+++ b/web/public/index.css
@@ -110,6 +110,11 @@ pre > code {
   margin: 0.5em 0 0.2em;
 }
 
+/* A coloured badge is a warning — full opacity so the colour reads true. */
+.payload-size--ok { color: #1a7f37; opacity: 1; }
+.payload-size--warn { color: #bf8700; opacity: 1; }
+.payload-size--over { color: #d1242f; opacity: 1; }
+
 @media (prefers-color-scheme: dark) {
   :root {
     --bg-color: #191b21;

--- a/web/views/index.erb
+++ b/web/views/index.erb
@@ -66,7 +66,7 @@
 
         <iframe style="width: 800px; height: 480px; border: 1px solid black; background: white;">Rendering…</iframe>
 
-        <div class="payload-size">Payload: <%= format_bytes(@payload_size) %></div>
+        <div class="payload-size <%= payload_size_class(@payload_size) %>">Payload: <%= format_bytes(@payload_size) %></div>
         <pre id="user-data"><code><%= h @user_data %></code></pre>
     </main>
 </body>


### PR DESCRIPTION
## Summary

Six independent pieces of work from the post-0.8.0 backlog, one commit each, plus
two follow-up commits. Every change ships with specs; the full suite is green and
RuboCop is clean.

| Change | Resolves |
|--------|----------|
| `trmnlp init` no longer creates read-only project files | #83 |
| Payload-size badge is colour-coded by size | #67 |
| Non-JSON poll responses are exposed as `{{ data }}` | #81 |
| `trmnlp build --png` renders a PNG per view | #92 |
| CLI output is TTY-aware coloured | #33 |
| SimpleCov coverage tracking + lint-check specs | — |

## Details

### Fixed `init` creating read-only files — #83

`init` copied templates with a bare `FileUtils.cp`, which preserves the source file
mode. On read-only gem installs — NixOS stores gems under `/nix/store` at `0444` —
the generated project was not editable. The copy now adds owner-write while keeping
any executable bit, so `bin/trmnlp` stays runnable.

### Payload-size colour coding — #67

The merge-variable payload size was shown as plain text. The badge now turns yellow
from 75 KB and red from 100 KB, so an oversized payload is obvious before the plugin
misbehaves in production.

### Non-JSON polling key — #81

A `text/html` or `text/plain` poll response that is not secretly JSON was exposed to
the template as `{{ text }}`, while the hosted service uses `{{ data }}`. They now
match, so a plugin previews locally the same way it runs in production.

### `trmnlp build --png` — #92

`build` only wrote HTML. `build --png` now screenshots each view through the existing
quantization pipeline and writes a PNG alongside. `--width`, `--height`, and
`--color-depth` flags override the defaults for parity with the serve PNG route. The
headless-Firefox factory moved out of `serve` into a shared `FirefoxDriver` module,
since `build` is its second consumer.

### TTY-aware coloured output — #33

`Reporter` hand-rolled ANSI escape codes and emitted them unconditionally, so colour
leaked into piped output as unreadable sequences. Colour is now suppressed off a
terminal and extended to warnings and the fatal-error message. (A colour gem was
trialed, then dropped in favour of a four-line hand-rolled colorizer to avoid three
transitive dependencies — see the commit history.)

### Coverage tracking + lint specs

SimpleCov now runs from `spec_helper`; CI gates on a 90% line-coverage floor
(currently 92.5%). The 11 lint checks that had no dedicated spec — previously
exercised only incidentally through the lint command — each gained a focused
pass/fail spec.

## Closes

Closes #33
Closes #67
Closes #81
Closes #83
Closes #92

## Test plan

- [x] `bundle exec rspec` — 268 examples, 0 failures
- [x] `bundle exec rubocop` — 111 files, no offenses
- [x] SimpleCov floor enforced in CI — `CI=true bundle exec rspec` exits 0 at 92.5%
- [x] `trmnlp build --png` against `examples/hn-stories` — four 800×480 PNGs, real render
- [x] `trmnlp lint` piped — no ANSI codes; in a terminal — coloured
