### PR TITLE
Refactored release workflow for parallel multi-arch builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,16 @@
 # exists and skips if so. The workflow can be safely re-run after a
 # partial failure (e.g. tag pushed but gem publish failed).
 #
+# Architecture:
+#   prepare           - tag, gem publish, decide whether image needs building
+#   docker-build      - matrix: amd64 on x86 runner, arm64 on native arm runner
+#   docker-manifest   - merge per-arch digests into the multi-arch tags
+#
+# Why split per-arch: building linux/arm64 under QEMU emulation on an x86
+# runner takes ~13 min. Native arm64 (`ubuntu-24.04-arm`) takes ~3 min, in
+# parallel with amd64. Layer caching (type=gha) makes warm reruns faster
+# still. Total release wall time drops from ~14 min to ~3 min.
+#
 # Required repository secrets:
 #   RUBYGEMS_API_KEY  - API key from https://rubygems.org/profile/api_keys
 #   DOCKER_USERNAME   - Docker Hub username
@@ -19,69 +29,79 @@ on:
     paths:
       - "lib/trmnlp/version.rb"
 
-# Serialize releases: a second run queues behind the first instead of
-# racing it on the tag push. Never cancel an in-flight release — that
-# could interrupt a publish midway and leave a partial state.
+# Serialize releases across the WHOLE workflow: a second run queues
+# behind the first instead of racing it on the tag push. Never cancel
+# an in-flight release — that could interrupt a publish midway.
 concurrency:
   group: release
   cancel-in-progress: false
 
+env:
+  IMAGE: trmnl/trmnlp
+
 jobs:
-  release:
+  prepare:
     runs-on: ubuntu-latest
     permissions:
       contents: write # needed to push the git tag
+    outputs:
+      version: ${{ steps.read.outputs.version }}          # e.g. v0.8.3
+      gem_version: ${{ steps.read.outputs.gem_version }}  # e.g. 0.8.3
+      ruby_version: ${{ steps.read.outputs.ruby_version }}
+      image_exists: ${{ steps.image.outputs.exists }}
+      has_docker_creds: ${{ steps.dockercreds.outputs.has }}
     steps:
       - uses: actions/checkout@v6
 
-      - name: Read Ruby version
-        run: echo "RUBY_VERSION=$(cat .ruby-version)" >> "$GITHUB_ENV"
+      - name: Read versions
+        id: read
+        run: |
+          GEM_VERSION=$(ruby -r ./lib/trmnlp/version -e 'puts TRMNLP::VERSION')
+          echo "version=v${GEM_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "gem_version=${GEM_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "ruby_version=$(cat .ruby-version)" >> "$GITHUB_OUTPUT"
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ env.RUBY_VERSION }}
+          ruby-version-file: .ruby-version
           bundler-cache: true
 
       - name: Run specs
         run: bundle exec rspec
 
-      - name: Read gem version
-        run: |
-          GEM_VERSION=$(ruby -r ./lib/trmnlp/version -e 'puts TRMNLP::VERSION')
-          echo "VERSION=v${GEM_VERSION}" >> "$GITHUB_ENV"
-          echo "GEM_VERSION=${GEM_VERSION}" >> "$GITHUB_ENV"
-
       # Git tag
       - name: Check if tag already exists
+        id: tag
         run: |
-          if git ls-remote --tags origin "refs/tags/${{ env.VERSION }}" | grep -q .; then
-            echo "TAG_EXISTS=true" >> "$GITHUB_ENV"
+          if git ls-remote --tags origin "refs/tags/${{ steps.read.outputs.version }}" | grep -q .; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create git tag
-        if: env.TAG_EXISTS != 'true'
+        if: steps.tag.outputs.exists != 'true'
         run: |
-          git tag "${{ env.VERSION }}"
-          git push origin "${{ env.VERSION }}"
+          git tag "${{ steps.read.outputs.version }}"
+          git push origin "${{ steps.read.outputs.version }}"
 
       # RubyGems
       - name: Check if gem version already published
+        id: gem
         run: |
-          if gem info trmnl_preview -r -e -v "${{ env.GEM_VERSION }}" 2>/dev/null | grep -q "${{ env.GEM_VERSION }}"; then
-            echo "GEM_EXISTS=true" >> "$GITHUB_ENV"
+          if gem info trmnl_preview -r -e -v "${{ steps.read.outputs.gem_version }}" 2>/dev/null | grep -q "${{ steps.read.outputs.gem_version }}"; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
           fi
 
-      # No RubyGems key → skip the publish (a maintainer pushes it manually) so the Docker steps still run.
       - name: Check for RubyGems API key
+        id: rubygemskey
         env:
           RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
         run: |
           if [ -n "$RUBYGEMS_API_KEY" ]; then
-            echo "HAS_RUBYGEMS_KEY=true" >> "$GITHUB_ENV"
+            echo "has=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build and publish gem
-        if: env.GEM_EXISTS != 'true' && env.HAS_RUBYGEMS_KEY == 'true'
+        if: steps.gem.outputs.exists != 'true' && steps.rubygemskey.outputs.has == 'true'
         run: |
           gem build trmnl_preview.gemspec
           gem push trmnl_preview-*.gem
@@ -89,41 +109,107 @@ jobs:
           GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
 
       - name: Warn that gem publish was skipped
-        if: env.GEM_EXISTS != 'true' && env.HAS_RUBYGEMS_KEY != 'true'
-        run: echo "::warning::RUBYGEMS_API_KEY not set — gem ${{ env.GEM_VERSION }} was NOT published. Push it manually."
+        if: steps.gem.outputs.exists != 'true' && steps.rubygemskey.outputs.has != 'true'
+        run: echo "::warning::RUBYGEMS_API_KEY not set — gem ${{ steps.read.outputs.gem_version }} was NOT published. Push it manually."
 
-      # Docker image
+      # Docker pre-check — short-circuits both arch jobs if image already exists
       - name: Check if Docker image already exists
+        id: image
         run: |
-          if docker manifest inspect "trmnl/trmnlp:${{ env.VERSION }}" > /dev/null 2>&1; then
-            echo "IMAGE_EXISTS=true" >> "$GITHUB_ENV"
+          if docker manifest inspect "${{ env.IMAGE }}:${{ steps.read.outputs.version }}" > /dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Login to Docker Hub
-        if: env.IMAGE_EXISTS != 'true'
-        uses: docker/login-action@v3
+      - name: Check for Docker Hub credentials
+        id: dockercreds
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          if [ -n "$DOCKER_USERNAME" ] && [ -n "$DOCKER_PASSWORD" ]; then
+            echo "has=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  # ---- Per-arch image builds, in parallel, on NATIVE runners ----
+  docker-build:
+    needs: prepare
+    if: needs.prepare.outputs.image_exists != 'true' && needs.prepare.outputs.has_docker_creds == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Setup QEMU
-        if: env.IMAGE_EXISTS != 'true'
-        uses: docker/setup-qemu-action@v3
-
-      - name: Setup Docker Buildx
-        if: env.IMAGE_EXISTS != 'true'
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push Docker image
-        if: env.IMAGE_EXISTS != 'true'
+      # Build for this single arch and push by digest (no tag yet).
+      # The manifest job below stitches the per-arch digests into the
+      # final `:latest` and `:vX.Y.Z` multi-arch tags.
+      - id: build
         uses: docker/build-push-action@v6
         with:
+          context: .
+          platforms: ${{ matrix.platform }}
           build-args: |
-            RUBY_VERSION=${{ env.RUBY_VERSION }}
-          platforms: |
-            linux/amd64
-            linux/arm64
-          push: true
-          tags: |
-            trmnl/trmnlp:latest
-            trmnl/trmnlp:${{ env.VERSION }}
+            RUBY_VERSION=${{ needs.prepare.outputs.ruby_version }}
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+
+      # Export this build's digest as an artifact so the manifest job
+      # can pick it up. The empty file's NAME is the digest.
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # ---- Stitch the per-arch digests into a multi-arch manifest ----
+  docker-manifest:
+    needs: [prepare, docker-build]
+    if: needs.prepare.outputs.image_exists != 'true' && needs.prepare.outputs.has_docker_creds == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Create multi-arch manifest
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            -t ${{ env.IMAGE }}:latest \
+            -t ${{ env.IMAGE }}:${{ needs.prepare.outputs.version }} \
+            $(printf '${{ env.IMAGE }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: docker buildx imagetools inspect ${{ env.IMAGE }}:${{ needs.prepare.outputs.version }}


### PR DESCRIPTION
## Summary

Drops release wall time from **~13 min** to **~3 min cold / ~45 s warm**.

## Why

The old workflow built \`linux/arm64\` under QEMU emulation on an x86 runner. Every arm64 instruction was software-translated, and the apt-get install of imagemagick + firefox + python + node + php + git compounded the slowdown. The actual build was ~13 min, of which ~12:58 was the Docker step.

## What changed

Split the single Docker build into:

1. \`prepare\` — specs, tag, gem publish, image-exists pre-check (gates the build jobs)
2. \`docker-build\` — matrix: amd64 on \`ubuntu-latest\`, arm64 on \`ubuntu-24.04-arm\` (native), in parallel, pushed by digest
3. \`docker-manifest\` — stitches the per-arch digests into the final \`:latest\` and \`:vX.Y.Z\` tags

Cache layered on with \`type=gha\` scoped per arch.

## Verification

Tested end-to-end on the \`release-workflow-test\` branch (\`.github/workflows/release-test.yaml\`, to be deleted after this merges):

| Run | Wall time |
|---|---|
| Cold (no cache) | 3 m 53 s |
| Warm (cache hit) | 44 s |
| Old workflow (for reference) | 13 m 45 s |

Manifest verified to contain both \`linux/arm64\` and \`linux/amd64\` digests under a single \`application/vnd.oci.image.index.v1+json\` index.

## Follow-up cleanup (after merge)

- Delete \`release-workflow-test\` branch
- Delete \`trmnl/trmnlp:test-f09b0fe\` and \`trmnl/trmnlp:test-712c087\` from Docker Hub
- (Optional, not urgent) Bump deprecated Node 20 actions ahead of the June 2026 forced switch

## Trigger note

This file change does NOT trigger the Release workflow itself (path filter is \`lib/trmnlp/version.rb\`), so merging is safe. New pipeline takes effect on the NEXT version bump.