### PR TITLE
0.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 
 # Changelog
 
+## 0.8.4
+
+- Fixed `trmnlp serve` hanging after switching between browser tabs. Live reload now uses `rack.hijack` so SSE connections release their Puma worker thread immediately instead of holding it for the lifetime of the tab.
+- Fixed Ctrl-C requiring three presses to stop the dev server. filewatcher 3.0.1 was clobbering Puma's signal handlers with its own `trap('INT') { exit }`.
+- Fixed scaffolded plugins silently skipping their transform when `settings.yml` had `serverless_language: ''`. The empty string was treated as truthy in Ruby and short-circuited the file-extension fallback.
+- Docker examples in the README now use `--pull always` (and `pull_policy: always` for Compose) so a new release is picked up on the next `docker run` without a manual pull.
+
 ## 0.8.3
 
 - `trmnlp init` and `trmnlp clone` now scaffold a `.github/workflows/trmnl.yml` CI workflow and a `.gitignore`, and run `git init -b main`, so a cloned plugin is ready to push to GitHub and deploy on every commit to `main`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trmnl_preview (0.8.3)
+    trmnl_preview (0.8.4)
       activesupport (~> 8.0)
       cgi (~> 0.5)
       faraday (~> 2.1)

--- a/README.md
+++ b/README.md
@@ -203,10 +203,13 @@ trmnlp serve
 
 ```sh
 docker run \
+    --pull always \
     --publish 4567:4567 \
     --volume "$(pwd):/plugin" \
     trmnl/trmnlp serve
 ```
+
+`--pull always` checks the registry on every run and pulls a newer image if one exists, so you don't have to remember to `docker pull` after each release.
 
 Inside a container, `serve` binds to `0.0.0.0` automatically (it detects `/.dockerenv`) so the preview is reachable from your host browser. Outside Docker it binds to `127.0.0.1`.
 
@@ -218,6 +221,7 @@ For running multiple commands (login, clone, serve), you can start an interactiv
 
 ```sh
 docker run -it \
+    --pull always \
     --publish 4567:4567 \
     --volume "$HOME/.config/trmnlp:/root/.config/trmnlp" \
     --volume "$(pwd):/plugin" \
@@ -244,6 +248,7 @@ For a checked-in config — like [`examples/hn-stories/`](examples/hn-stories/) 
 services:
   trmnlp:
     image: trmnl/trmnlp
+    pull_policy: always
     command: ["serve"]
     ports:
       - "4567:4567"

--- a/examples/hn-stories/docker-compose.yml
+++ b/examples/hn-stories/docker-compose.yml
@@ -9,6 +9,7 @@
 services:
   trmnlp:
     image: trmnl/trmnlp:latest
+    pull_policy: always
     command: ["serve"]
     ports:
       - "4567:4567"

--- a/lib/trmnlp/app.rb
+++ b/lib/trmnlp/app.rb
@@ -77,17 +77,40 @@ module TRMNLP
       JSON.pretty_generate(@user_data_assembler.call(device:))
     end
 
-    # Live reload is a one-directional server->browser push, so it uses
-    # server-sent events rather than a websocket. Each client gets a blocking
-    # queue; the stream thread parks on queue.pop until the watcher broadcasts.
+    # Live reload uses rack.hijack so the Puma worker thread is released the
+    # instant we have the raw socket — broadcasting then runs on our own
+    # thread, never competing with HTTP request workers. Adapted from the
+    # Faye::EventSource pattern in faye-websocket (lib/faye/rack_stream.rb)
+    # but without the EventMachine dependency: where Faye uses EM.attach to
+    # get a reactor callback on socket close, we detect close synchronously
+    # via the IOError/EPIPE raised by the next heartbeat write.
+    HEARTBEAT_SECONDS = 5
+
     get '/live_reload' do
-      content_type 'text/event-stream'
+      hijack = env['rack.hijack']
+      halt 500, 'rack.hijack unavailable' unless hijack
+      hijack.call
+      io = env['rack.hijack_io']
+
       queue = Thread::Queue.new
       @live_reload_clients << queue
-      stream(:keep_open) do |out|
-        out.callback { @live_reload_clients.delete(queue) }
-        out << queue.pop until out.closed?
+
+      Thread.new do
+        io.write("HTTP/1.1 200 OK\r\n" \
+                 "Content-Type: text/event-stream\r\n" \
+                 "Cache-Control: no-cache\r\n" \
+                 "Connection: close\r\n\r\n")
+        run_live_reload_loop(io, queue)
+      rescue IOError, Errno::EPIPE, Errno::ECONNRESET
+        # client disconnected mid-write — normal termination
+      ensure
+        @live_reload_clients.delete(queue)
+        io.close
       end
+
+      # -1 status tells the server we've hijacked the response. The body
+      # is never iterated; the thread above owns the socket from here.
+      [-1, {}, []]
     end
 
     get '/poll' do
@@ -127,6 +150,16 @@ module TRMNLP
     end
 
     private
+
+    # On timeout (queue idle), a colon-prefixed SSE comment line both
+    # keeps proxies awake and surfaces a dead client via the next
+    # io.write — the route's outer rescue then cleans up.
+    def run_live_reload_loop(io, queue)
+      loop do
+        message = queue.pop(timeout: HEARTBEAT_SECONDS)
+        io.write(message || ": heartbeat\n\n")
+      end
+    end
 
     # ScreenGenerator is request-scoped — it carries the per-request width,
     # height, and color_depth — so it is built here rather than on the shared

--- a/lib/trmnlp/commands/serve.rb
+++ b/lib/trmnlp/commands/serve.rb
@@ -22,6 +22,9 @@ module TRMNLP
         App.set(:browser_pool, BrowserPool.new(driver_factory: FirefoxDriver.method(:build)))
         App.set(:bind, options.bind)
         App.set(:port, options.port)
+        # Each live-reload SSE connection holds a Puma thread for the tab's
+        # lifetime; the default 0:5 pool runs out fast with multiple tabs open.
+        App.set(:server_settings, Threads: '1:16')
         permit_all_hosts if codespaces?
 
         # Finally, start the app!

--- a/lib/trmnlp/config/plugin.rb
+++ b/lib/trmnlp/config/plugin.rb
@@ -73,8 +73,13 @@ module TRMNLP
       # Explicit language for transform.* code. If absent, the language
       # is inferred from the file extension by Paths#transform_file.
       # This one lives on the plugin (settings.yml) because production
-      # stores it on the plugin_setting record.
-      def serverless_language = @config['serverless_language']
+      # stores it on the plugin_setting record. The scaffold emits
+      # `serverless_language: ''`, so empty strings collapse to nil here
+      # to let the `||` in the pipeline fall through to the inferred value.
+      def serverless_language
+        value = @config['serverless_language']
+        value unless value.to_s.empty?
+      end
 
       # The TRMNL design-system version this plugin renders against.
       # Lives on the plugin (settings.yml), like serverless_language,

--- a/lib/trmnlp/version.rb
+++ b/lib/trmnlp/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TRMNLP
-  VERSION = '0.8.3'
+  VERSION = '0.8.4'
 end

--- a/lib/trmnlp/watcher.rb
+++ b/lib/trmnlp/watcher.rb
@@ -4,6 +4,24 @@ require 'filewatcher'
 
 require_relative 'reporter'
 
+# filewatcher 3.0.1's #watch installs `trap('INT') { exit }` (and HUP/TERM)
+# unconditionally, clobbering Puma's clean-shutdown handler — Ctrl-C then
+# raises SystemExit instead of triggering Puma's graceful stop, which is
+# why the container needs three SIGINTs to die. The gem offers no opt-out;
+# its supported shutdown is Filewatcher#stop, which we're not using. We
+# replace the trap-installing #watch with the rest of its body so signals
+# fall through to whatever handler the host process installed (Puma).
+Filewatcher.prepend(Module.new do
+  def watch(&on_update)
+    @on_update = on_update
+    @keep_watching = true
+    yield({ '' => '' }) if @immediate
+    main_cycle
+    @end_snapshot = current_snapshot
+    finalize(&on_update)
+  end
+end)
+
 module TRMNLP
   class Watcher
     def initialize(config:, user_data_assembler:, transform_pipeline:, reporter: Reporter.new)

--- a/spec/lib/trmnlp/config/plugin_spec.rb
+++ b/spec/lib/trmnlp/config/plugin_spec.rb
@@ -88,6 +88,32 @@ RSpec.describe TRMNLP::Config::Plugin do
     end
   end
 
+  describe '#serverless_language' do
+    context 'when settings.yml sets a language' do
+      before { plugin.instance_variable_set(:@config, { 'serverless_language' => 'python' }) }
+
+      it 'returns the configured language' do
+        expect(plugin.serverless_language).to eq('python')
+      end
+    end
+
+    context "when settings.yml has serverless_language: ''" do
+      before { plugin.instance_variable_set(:@config, { 'serverless_language' => '' }) }
+
+      it 'returns nil so the inferred extension wins' do
+        expect(plugin.serverless_language).to be_nil
+      end
+    end
+
+    context 'when settings.yml omits serverless_language' do
+      before { plugin.instance_variable_set(:@config, {}) }
+
+      it 'returns nil' do
+        expect(plugin.serverless_language).to be_nil
+      end
+    end
+  end
+
   describe '#reload!' do
     it 'raises a readable InvalidConfig when settings.yml is not valid YAML' do
       Dir.mktmpdir('trmnlp-plugin-') do |dir|


### PR DESCRIPTION
- Fixed `trmnlp serve` hanging after switching between browser tabs. Live reload now uses `rack.hijack` so SSE connections release their Puma worker thread immediately instead of holding it for the lifetime of the tab.
- Fixed Ctrl-C requiring three presses to stop the dev server. filewatcher 3.0.1 was clobbering Puma's signal handlers with its own `trap('INT') { exit }`.
- Fixed scaffolded plugins silently skipping their transform when `settings.yml` had `serverless_language: ''`. The empty string was treated as truthy in Ruby and short-circuited the file-extension fallback.
- Docker examples in the README now use `--pull always` (and `pull_policy: always` for Compose) so a new release is picked up on the next `docker run` without a manual pull.