### PR TITLE
Stub TRMNL::Liquid::RailsHelpers when ActionView is unavailable

### DIFF
--- a/lib/trmnlp.rb
+++ b/lib/trmnlp.rb
@@ -2,7 +2,9 @@
 
 module TRMNLP; end
 require 'oj'
+require 'trmnl/liquid'
 Oj.mimic_JSON
+TRMNL::Liquid::RailsHelpers = Module.new unless defined?(TRMNL::Liquid::RailsHelpers)
 require_relative 'trmnlp/errors'
 require_relative 'trmnlp/config'
 require_relative 'trmnlp/context'

--- a/spec/lib/trmnlp/liquid_spec.rb
+++ b/spec/lib/trmnlp/liquid_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe TRMNL::Liquid do
+  describe 'registered filters' do
+    it 'renders pluralize from the bundled filter set' do
+      environment = described_class.new
+      template = Liquid::Template.parse(%q({{ "person" | pluralize: 4, plural: 'people' }}), environment:)
+
+      expect(template.render).to eq('4 people')
+    end
+  end
+end


### PR DESCRIPTION
Ensure `trmnl-liquid` gem is available at runtime.

Fixes #104