### PR TITLE
0.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Changelog
 
+## 0.8.5
+
+- Fixed `pluralize`, `number_with_delimiter`, and `number_to_currency` Liquid filters raising `Liquid error: internal`. `trmnl-liquid` 0.7 moved `RailsHelpers` behind an opt-in `load(:rails)`, but the filters still probed `RailsHelpers.respond_to?` against the now-undefined constant. Stubbing an empty module makes the probe return false so the bundled fallback implementations run. (#105)
+
 ## 0.8.4
 
 - Fixed `trmnlp serve` hanging after switching between browser tabs. Live reload now uses `rack.hijack` so SSE connections release their Puma worker thread immediately instead of holding it for the lifetime of the tab.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trmnl_preview (0.8.4)
+    trmnl_preview (0.8.5)
       activesupport (~> 8.0)
       cgi (~> 0.5)
       faraday (~> 2.1)

--- a/lib/trmnlp/version.rb
+++ b/lib/trmnlp/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TRMNLP
-  VERSION = '0.8.4'
+  VERSION = '0.8.5'
 end


### PR DESCRIPTION
- Fixed `pluralize`, `number_with_delimiter`, and `number_to_currency` Liquid filters raising `Liquid error: internal`. `trmnl-liquid` 0.7 moved `RailsHelpers` behind an opt-in `load(:rails)`, but the filters still probed `RailsHelpers.respond_to?` against the now-undefined constant. Stubbing an empty module makes the probe return false so the bundled fallback implementations run. (#105)