### PR TITLE
Add missing field_types

### DIFF
--- a/db/data/form_fields.yml
+++ b/db/data/form_fields.yml
@@ -12,13 +12,23 @@ required_keys:
   - field_type
   - name
 field_types:
-  - text
-  - string
+  - author_bio
+  - boolean
+  - code
+  - copyable
+  - copyable_webhook_url
+  - date
+  - multi_string
   - number
   - password
-  - boolean
-  - xhrString
-  - xhrSelect
-  - xhrFunction
+  - plugin_instance_select
   - select
-  - author_bio
+  - string
+  - text
+  - time
+  - time_zone
+  - url
+  - xhrFunction
+  - xhrSelect
+  - xhrSelectSearch
+  - xhrString


### PR DESCRIPTION
Fixes warning when using [valid field types from the docs](https://help.trmnl.com/en/articles/10513740-custom-plugin-form-builder).

Fixes #107 