### PR TITLE
Make server base url configurable for BYOS support

### DIFF
--- a/lib/trmnlp/cli.rb
+++ b/lib/trmnlp/cli.rb
@@ -28,6 +28,7 @@ module TRMNLP
     end
 
     desc 'login', 'Authenticate with TRMNL server'
+    method_option :server, type: :string, aliases: '-s', desc: 'Server URL (default: https://trmnl.com)'
     def login
       Commands::Login.run(options)
     end

--- a/lib/trmnlp/commands/list.rb
+++ b/lib/trmnlp/commands/list.rb
@@ -16,7 +16,7 @@ module TRMNLP
         api = APIClient.new(config)
         response = api.get_plugin_settings
         plugins = (response || [])
-                  .select { |p| p['plugin_id'] == PRIVATE_PLUGIN_ID }
+                  .select { |p| p['plugin_id'].nil? || p['plugin_id'] == PRIVATE_PLUGIN_ID }
                   .sort_by { |p| (p['name'] || '').downcase }
 
         if plugins.empty?

--- a/lib/trmnlp/commands/login.rb
+++ b/lib/trmnlp/commands/login.rb
@@ -23,7 +23,7 @@ module TRMNLP
         api_key = prompt('API Key: ')
         raise InvalidApiKey, 'API key cannot be empty' if api_key.empty?
 
-        if options.server.nil? && config.app.base_uri.host.end_with?('trmnl.com')
+        if config.app.base_uri.host.end_with?('trmnl.com')
           raise InvalidApiKey, 'Invalid API key; did you copy it from the right place?' unless api_key.start_with?('user_')
         end
 

--- a/lib/trmnlp/commands/login.rb
+++ b/lib/trmnlp/commands/login.rb
@@ -10,34 +10,41 @@ module TRMNLP
 
       def call
         config.app.base_url = options.server if options.server
-
-        if config.app.logged_in?
-          anonymous_key = config.app.api_key[0..10] + ('*' * (config.app.api_key.length - 11))
-          reporter.info "Currently authenticated as: #{anonymous_key}"
-          confirm = prompt('You are already authenticated. Do you want to re-authenticate? (y/N): ')
-          return unless confirm.strip.downcase == 'y'
-        end
+        return unless confirm_reauthentication?
 
         reporter.info "Please visit #{config.app.account_uri} to grab your API key, then paste it here."
 
         api_key = prompt('API Key: ')
         raise InvalidApiKey, 'API key cannot be empty' if api_key.empty?
 
-        if config.app.base_uri.host.end_with?('trmnl.com')
-          raise InvalidApiKey, 'Invalid API key; did you copy it from the right place?' unless api_key.start_with?('user_')
+        if config.app.base_uri.host.end_with?('trmnl.com') && !api_key.start_with?('user_')
+          raise InvalidApiKey,
+                'Invalid API key; did you copy it from the right place?'
         end
 
         config.app.api_key = api_key
+        save_credentials
+      end
 
+      private
+
+      def confirm_reauthentication?
+        return true unless config.app.logged_in?
+
+        anonymous_key = config.app.api_key[0..10] + ('*' * (config.app.api_key.length - 11))
+        reporter.info "Currently authenticated as: #{anonymous_key}"
+        confirm = prompt('You are already authenticated. Do you want to re-authenticate? (y/N): ')
+        confirm.strip.downcase == 'y'
+      end
+
+      def save_credentials
         api_client = APIClient.new(config)
-        begin
-          user_info = api_client.get_me
-          reporter.info "Authenticated as #{user_info['name']} (#{user_info['email']})"
-          config.app.save
-          reporter.info "Saved changes to #{paths.app_config}"
-        rescue StandardError => e
-          raise AuthenticationFailed, "Authentication failed; changes were not saved.\n#{e.message}"
-        end
+        user_info = api_client.get_me
+        reporter.info "Authenticated as #{user_info['name']} (#{user_info['email']})"
+        config.app.save
+        reporter.info "Saved changes to #{paths.app_config}"
+      rescue StandardError => e
+        raise AuthenticationFailed, "Authentication failed; changes were not saved.\n#{e.message}"
       end
     end
   end

--- a/lib/trmnlp/commands/login.rb
+++ b/lib/trmnlp/commands/login.rb
@@ -6,9 +6,11 @@ require_relative '../api_client'
 module TRMNLP
   module Commands
     class Login < Base
-      Options = Data.define(:dir, :quiet)
+      Options = Data.define(:dir, :quiet, :server)
 
       def call
+        config.app.base_url = options.server if options.server
+
         if config.app.logged_in?
           anonymous_key = config.app.api_key[0..10] + ('*' * (config.app.api_key.length - 11))
           reporter.info "Currently authenticated as: #{anonymous_key}"
@@ -20,9 +22,9 @@ module TRMNLP
 
         api_key = prompt('API Key: ')
         raise InvalidApiKey, 'API key cannot be empty' if api_key.empty?
-        unless api_key.start_with?('user_')
-          raise InvalidApiKey,
-                'Invalid API key; did you copy it from the right place?'
+
+        if options.server.nil? && config.app.base_uri.host.end_with?('trmnl.com')
+          raise InvalidApiKey, 'Invalid API key; did you copy it from the right place?' unless api_key.start_with?('user_')
         end
 
         config.app.api_key = api_key

--- a/lib/trmnlp/config/app.rb
+++ b/lib/trmnlp/config/app.rb
@@ -30,6 +30,10 @@ module TRMNLP
         @config['api_key'] = key
       end
 
+      def base_url=(url)
+        @config['base_url'] = url
+      end
+
       def base_uri = URI.parse(@config['base_url'] || 'https://trmnl.com')
 
       def api_uri = URI.join(base_uri, '/api')

--- a/spec/lib/trmnlp/commands/list_spec.rb
+++ b/spec/lib/trmnlp/commands/list_spec.rb
@@ -50,6 +50,17 @@ RSpec.describe TRMNLP::Commands::List do
       expect(reporter.messages).to include(match(/No plugins found/))
     end
 
+    it 'shows plugins with nil plugin_id (LaraPaper format)' do
+      allow(api_client).to receive(:get_plugin_settings).and_return([
+        { 'id' => 'uuid-1', 'plugin_id' => nil, 'name' => 'My LaraPaper Plugin' }
+      ])
+
+      command.call
+      output = reporter.messages.join("\n")
+
+      expect(output).to include('My LaraPaper Plugin')
+    end
+
     it 'raises when not authenticated' do
       allow(context.config.app).to receive(:logged_in?).and_return(false)
 

--- a/spec/lib/trmnlp/commands/list_spec.rb
+++ b/spec/lib/trmnlp/commands/list_spec.rb
@@ -52,8 +52,9 @@ RSpec.describe TRMNLP::Commands::List do
 
     it 'shows plugins with nil plugin_id (LaraPaper format)' do
       allow(api_client).to receive(:get_plugin_settings).and_return([
-        { 'id' => 'uuid-1', 'plugin_id' => nil, 'name' => 'My LaraPaper Plugin' }
-      ])
+                                                                      { 'id' => 'uuid-1', 'plugin_id' => nil,
+                                                                        'name' => 'My LaraPaper Plugin' }
+                                                                    ])
 
       command.call
       output = reporter.messages.join("\n")

--- a/spec/lib/trmnlp/commands/login_spec.rb
+++ b/spec/lib/trmnlp/commands/login_spec.rb
@@ -5,7 +5,7 @@ require 'trmnlp/commands/login'
 
 RSpec.describe TRMNLP::Commands::Login do
   subject(:command) do
-    described_class.new(context:, options: described_class::Options.new(dir: fixtures_root, quiet: true))
+    described_class.new(context:, options: described_class::Options.new(dir: fixtures_root, quiet: true, server: nil))
   end
 
   let(:api_client) { instance_double(TRMNLP::APIClient) }
@@ -46,6 +46,39 @@ RSpec.describe TRMNLP::Commands::Login do
 
       expect { command.call }.to raise_error(TRMNLP::AuthenticationFailed, /Authentication failed/)
       expect(app_config).not_to have_received(:save)
+    end
+
+    context 'when --server is given' do
+      subject(:command) do
+        described_class.new(
+          context:,
+          options: described_class::Options.new(dir: fixtures_root, quiet: true, server: 'http://localhost')
+        )
+      end
+
+      it 'saves base_url to the app config' do
+        allow(app_config).to receive(:base_url=)
+        allow(command).to receive(:prompt).and_return('3|sanctumtoken')
+        allow(api_client).to receive(:get_me).and_return('name' => 'Bluey', 'email' => 'b@example.com')
+
+        command.call
+
+        expect(app_config).to have_received(:base_url=).with('http://localhost')
+      end
+
+      it 'accepts a Sanctum-format token without raising' do
+        allow(app_config).to receive(:base_url=)
+        allow(command).to receive(:prompt).and_return('3|sanctumtoken')
+        allow(api_client).to receive(:get_me).and_return('name' => 'Bluey', 'email' => 'b@example.com')
+
+        expect { command.call }.not_to raise_error
+      end
+    end
+
+    it 'still rejects a non-user_ key when targeting trmnl.com (default)' do
+      allow(command).to receive(:prompt).and_return('not_a_user_key')
+
+      expect { command.call }.to raise_error(TRMNLP::InvalidApiKey, /Invalid API key/)
     end
   end
 end

--- a/spec/lib/trmnlp/commands/login_spec.rb
+++ b/spec/lib/trmnlp/commands/login_spec.rb
@@ -57,17 +57,15 @@ RSpec.describe TRMNLP::Commands::Login do
       end
 
       it 'saves base_url to the app config' do
-        allow(app_config).to receive(:base_url=)
         allow(command).to receive(:prompt).and_return('3|sanctumtoken')
         allow(api_client).to receive(:get_me).and_return('name' => 'Bluey', 'email' => 'b@example.com')
 
         command.call
 
-        expect(app_config).to have_received(:base_url=).with('http://localhost')
+        expect(app_config.base_uri.to_s).to eq('http://localhost')
       end
 
       it 'accepts a Sanctum-format token without raising' do
-        allow(app_config).to receive(:base_url=)
         allow(command).to receive(:prompt).and_return('3|sanctumtoken')
         allow(api_client).to receive(:get_me).and_return('name' => 'Bluey', 'email' => 'b@example.com')
 

--- a/spec/lib/trmnlp/config/app_spec.rb
+++ b/spec/lib/trmnlp/config/app_spec.rb
@@ -65,6 +65,15 @@ RSpec.describe TRMNLP::Config::App do
     end
   end
 
+  describe '#base_url=' do
+    it 'persists the base_url to disk on save' do
+      app_config.base_url = 'http://localhost'
+      app_config.save
+
+      expect(YAML.safe_load(paths.app_config.read)).to include('base_url' => 'http://localhost')
+    end
+  end
+
   describe '#base_uri' do
     it 'defaults to trmnl.com' do
       expect(app_config.base_uri.to_s).to eq('https://trmnl.com')


### PR DESCRIPTION
This PR adds a `--server` flag to `trmnlp login` which allows using commands like `trmnlp push` with BYOS. This requires the server to implement the appropriate endpoints. See https://github.com/usetrmnl/larapaper/pull/256 for an example.

I agree to license this change under MIT.