### PR TITLE
Fix login --server crash on scheme-less URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 
 # Changelog
 
+## 0.8.8
+
+- Added a `--server` flag to `trmnlp login` so commands like `trmnlp push` can target a self-hosted (BYOS) server. The chosen URL is saved as `base_url`, and the `user_` API key prefix is only required for trmnl.com; BYOS servers accept their own token formats. A scheme-less `--server` value (such as `localhost:3000`) no longer crashes the host check. (#113)
+- `trmnlp list` now shows plugins with a nil `plugin_id`, which BYOS servers like LaraPaper return. (#113)
+
 ## 0.8.7
 
 - Fixed `.trmnlp.yml` `variables` overrides under the `trmnl` namespace being dropped. The assembler re-applied the pre-override namespace after the transform, clobbering user overrides like `trmnl.user.time_zone`. (#110)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trmnl_preview (0.8.7)
+    trmnl_preview (0.8.8)
       activesupport (~> 8.0)
       cgi (~> 0.5)
       faraday (~> 2.1)

--- a/lib/trmnlp/commands/login.rb
+++ b/lib/trmnlp/commands/login.rb
@@ -17,7 +17,8 @@ module TRMNLP
         api_key = prompt('API Key: ')
         raise InvalidApiKey, 'API key cannot be empty' if api_key.empty?
 
-        if config.app.base_uri.host.end_with?('trmnl.com') && !api_key.start_with?('user_')
+        # Only trmnl.com issues user_-prefixed keys; BYOS servers use their own token formats (e.g. Sanctum).
+        if config.app.trmnl_host? && !api_key.start_with?('user_')
           raise InvalidApiKey,
                 'Invalid API key; did you copy it from the right place?'
         end

--- a/lib/trmnlp/config/app.rb
+++ b/lib/trmnlp/config/app.rb
@@ -36,6 +36,9 @@ module TRMNLP
 
       def base_uri = URI.parse(@config['base_url'] || 'https://trmnl.com')
 
+      # Scheme-less base_urls (e.g. "localhost:3000") parse to a nil host, so guard before matching.
+      def trmnl_host? = !!base_uri.host&.end_with?('trmnl.com')
+
       def api_uri = URI.join(base_uri, '/api')
 
       def account_uri = URI.join(base_uri, '/account')

--- a/lib/trmnlp/version.rb
+++ b/lib/trmnlp/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TRMNLP
-  VERSION = '0.8.7'
+  VERSION = '0.8.8'
 end

--- a/spec/lib/trmnlp/commands/list_spec.rb
+++ b/spec/lib/trmnlp/commands/list_spec.rb
@@ -50,16 +50,13 @@ RSpec.describe TRMNLP::Commands::List do
       expect(reporter.messages).to include(match(/No plugins found/))
     end
 
-    it 'shows plugins with nil plugin_id (LaraPaper format)' do
-      allow(api_client).to receive(:get_plugin_settings).and_return([
-                                                                      { 'id' => 'uuid-1', 'plugin_id' => nil,
-                                                                        'name' => 'My LaraPaper Plugin' }
-                                                                    ])
+    it 'includes plugins with a nil plugin_id (BYOS servers like LaraPaper)' do
+      plugins = [{ 'id' => 'uuid-1', 'plugin_id' => nil, 'name' => 'My BYOS Plugin' }]
+      allow(api_client).to receive(:get_plugin_settings).and_return(plugins)
 
       command.call
-      output = reporter.messages.join("\n")
 
-      expect(output).to include('My LaraPaper Plugin')
+      expect(reporter.messages.join("\n")).to include('My BYOS Plugin')
     end
 
     it 'raises when not authenticated' do

--- a/spec/lib/trmnlp/commands/login_spec.rb
+++ b/spec/lib/trmnlp/commands/login_spec.rb
@@ -5,9 +5,10 @@ require 'trmnlp/commands/login'
 
 RSpec.describe TRMNLP::Commands::Login do
   subject(:command) do
-    described_class.new(context:, options: described_class::Options.new(dir: fixtures_root, quiet: true, server: nil))
+    described_class.new(context:, options: described_class::Options.new(dir: fixtures_root, quiet: true, server:))
   end
 
+  let(:server) { nil }
   let(:api_client) { instance_double(TRMNLP::APIClient) }
   let(:fixtures_root) { File.expand_path('../../../fixtures', __dir__) }
   let(:context) { TRMNLP::Context.new(fixtures_root) }
@@ -26,7 +27,7 @@ RSpec.describe TRMNLP::Commands::Login do
       expect { command.call }.to raise_error(TRMNLP::InvalidApiKey, /cannot be empty/)
     end
 
-    it 'rejects a key that does not start with user_' do
+    it 'rejects a trmnl.com key that is not user_-prefixed' do
       allow(command).to receive(:prompt).and_return('not_a_user_key')
       expect { command.call }.to raise_error(TRMNLP::InvalidApiKey, /Invalid API key/)
     end
@@ -48,35 +49,46 @@ RSpec.describe TRMNLP::Commands::Login do
       expect(app_config).not_to have_received(:save)
     end
 
-    context 'when --server is given' do
-      subject(:command) do
-        described_class.new(
-          context:,
-          options: described_class::Options.new(dir: fixtures_root, quiet: true, server: 'http://localhost')
-        )
+    context 'when already authenticated and re-authentication is declined' do
+      before do
+        allow(app_config).to receive(:logged_in?).and_return(true)
+        allow(app_config).to receive(:api_key).and_return('user_existing_key')
+        allow(command).to receive(:prompt).and_return('n')
       end
 
-      it 'saves base_url to the app config' do
+      it 'aborts without saving' do
+        command.call
+        expect(app_config).not_to have_received(:save)
+      end
+    end
+
+    context 'when --server targets a BYOS host' do
+      let(:server) { 'http://localhost' }
+
+      before do
         allow(command).to receive(:prompt).and_return('3|sanctumtoken')
         allow(api_client).to receive(:get_me).and_return('name' => 'Bluey', 'email' => 'b@example.com')
+      end
 
+      it 'persists the server as the base_uri' do
         command.call
-
         expect(app_config.base_uri.to_s).to eq('http://localhost')
       end
 
-      it 'accepts a Sanctum-format token without raising' do
+      it 'accepts a non-user_ token without raising' do
+        expect { command.call }.not_to raise_error
+      end
+    end
+
+    context 'when --server is scheme-less' do
+      let(:server) { 'localhost:3000' }
+
+      it 'does not crash on the host check' do
         allow(command).to receive(:prompt).and_return('3|sanctumtoken')
         allow(api_client).to receive(:get_me).and_return('name' => 'Bluey', 'email' => 'b@example.com')
 
         expect { command.call }.not_to raise_error
       end
-    end
-
-    it 'still rejects a non-user_ key when targeting trmnl.com (default)' do
-      allow(command).to receive(:prompt).and_return('not_a_user_key')
-
-      expect { command.call }.to raise_error(TRMNLP::InvalidApiKey, /Invalid API key/)
     end
   end
 end

--- a/spec/lib/trmnlp/config/app_spec.rb
+++ b/spec/lib/trmnlp/config/app_spec.rb
@@ -66,11 +66,30 @@ RSpec.describe TRMNLP::Config::App do
   end
 
   describe '#base_url=' do
-    it 'persists the base_url to disk on save' do
+    it 'updates base_uri' do
       app_config.base_url = 'http://localhost'
-      app_config.save
+      expect(app_config.base_uri.to_s).to eq('http://localhost')
+    end
+  end
 
-      expect(YAML.safe_load(paths.app_config.read)).to include('base_url' => 'http://localhost')
+  describe '#trmnl_host?' do
+    it 'is true for the default host' do
+      expect(app_config.trmnl_host?).to be(true)
+    end
+
+    it 'is true for a trmnl.com subdomain' do
+      app_config.base_url = 'https://staging.trmnl.com'
+      expect(app_config.trmnl_host?).to be(true)
+    end
+
+    it 'is false for a BYOS host' do
+      app_config.base_url = 'http://localhost'
+      expect(app_config.trmnl_host?).to be(false)
+    end
+
+    it 'is false (not nil) for a scheme-less base_url' do
+      app_config.base_url = 'localhost:3000'
+      expect(app_config.trmnl_host?).to be(false)
     end
   end
 


### PR DESCRIPTION
Follow-up to #113.

- Fixes `trmnlp login --server` crashing on scheme-less URLs like `localhost:3000`, where `URI.parse` returns a nil host
- Moves the trmnl.com host check onto `Config::App#trmnl_host?`
- Reworks the login, list, and app config specs and adds coverage for the BYOS and scheme-less login paths
- Bumps version to 0.8.8 and adds a changelog entry for the BYOS login support