### PR TITLE
Fix Python transforms on Windows (resolve interpreter from PATH candidates)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Changelog
 
+## 0.8.10
+
+- Fixed Python serverless transforms failing on Windows. The local subprocess backend hardcoded `python3`, which the python.org Windows installer does not put on PATH (it installs `python` and the `py` launcher), so every Python transform raised "interpreter not available". The interpreter is now resolved from a per-language list of command candidates (`python3` then `python`) using a cross-platform PATH lookup, leaving POSIX behavior unchanged. (#116)
+
 ## 0.8.9
 
 - Fixed `trmnlp serve` binding to localhost under Podman, which left the dev server unreachable through published ports. Container detection only looked for `/.dockerenv`, which Docker writes but Podman does not, so `serve` fell back to `127.0.0.1`. It now also checks for `/run/.containerenv`, which Podman writes, so the automatic `0.0.0.0` bind works for both runtimes. (#112)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## 0.8.10
 
-- Fixed Python serverless transforms failing on Windows. The local subprocess backend hardcoded `python3`, which the python.org Windows installer does not put on PATH (it installs `python` and the `py` launcher), so every Python transform raised "interpreter not available". The interpreter is now resolved from a per-language list of command candidates (`python3` then `python`) using a cross-platform PATH lookup, leaving POSIX behavior unchanged. (#116)
+- Fixed Python serverless transforms failing on Windows. The local subprocess backend hardcoded `python3`, which the python.org Windows installer does not put on PATH (it installs `python` and the `py` launcher), so every Python transform raised "interpreter not available". The interpreter is now resolved from a per-language list of command candidates (`python3`, then `python`, then the `py` launcher) using a cross-platform PATH lookup, leaving POSIX behavior unchanged. (#116)
 
 ## 0.8.9
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trmnl_preview (0.8.9)
+    trmnl_preview (0.8.10)
       activesupport (~> 8.0)
       cgi (~> 0.5)
       faraday (~> 2.1)

--- a/lib/trmnlp/transform_backend/subprocess.rb
+++ b/lib/trmnlp/transform_backend/subprocess.rb
@@ -4,6 +4,7 @@ require 'open3'
 require 'tmpdir'
 
 require_relative '../transform_client'
+require_relative 'which'
 require_relative 'wrapper'
 
 module TRMNLP
@@ -19,16 +20,16 @@ module TRMNLP
       # Seconds a TERM'd process is given to exit before escalating to KILL.
       GRACE_PERIOD = 0.1
 
-      # Each language lists its interpreter command candidates in priority
-      # order. The first one found on PATH wins, so transforms stay portable
-      # across platforms that name the same interpreter differently — most
-      # notably Windows, where Python is installed as `python` with no
-      # `python3` on PATH.
+      # Candidate commands per language, highest priority first. Windows is
+      # why a language needs more than one: its python.org installer provides
+      # `python` and the `py` launcher but no `python3`. `py` ranks last yet
+      # is the surest Windows hit — it stays on PATH even when the installer's
+      # optional "Add to PATH" step is skipped.
       INTERPRETERS = {
-        'python' => { cmds: %w[python3 python], ext: 'py' },
-        'ruby' => { cmds: %w[ruby],             ext: 'rb' },
-        'node' => { cmds: %w[node],             ext: 'js' },
-        'php' => { cmds: %w[php],               ext: 'php' }
+        'python' => { cmds: %w[python3 python py], ext: 'py' },
+        'ruby' => { cmds: %w[ruby],                ext: 'rb' },
+        'node' => { cmds: %w[node],                ext: 'js' },
+        'php' => { cmds: %w[php],                  ext: 'php' }
       }.freeze
 
       def execute(code:, language:, stdin: '', timeout_seconds: DEFAULT_TIMEOUT)
@@ -45,33 +46,10 @@ module TRMNLP
           output_path = File.join(dir, 'output.json')
           src_path = File.join(dir, "transform.#{spec[:ext]}")
           File.write(src_path, Wrapper.for(language, code, sink_for(language, output_path)))
-          run_process(resolve_cmd(spec[:cmds]), src_path, stdin, timeout_seconds, output_path)
+          run_process(Which.resolve(spec[:cmds]), src_path, stdin, timeout_seconds, output_path)
         end
       rescue Errno::ENOENT, Errno::EACCES => e
         failure("interpreter not available: #{e.message}")
-      end
-
-      # First candidate present on PATH, falling back to the first name so a
-      # genuinely missing interpreter still surfaces a sensible
-      # "interpreter not available" error from run_process.
-      def resolve_cmd(cmds)
-        cmds.find { |c| which(c) } || cmds.first
-      end
-
-      # Minimal cross-platform `which`. On Windows PATHEXT lists the
-      # executable suffixes (.EXE/.BAT/...) to try; on POSIX it is unset, so
-      # we fall back to a single bare-name lookup. File.executable? maps to
-      # the exec bit on POSIX and to a recognized extension on Windows.
-      def which(cmd)
-        exts = ENV.fetch('PATHEXT', '').split(File::PATH_SEPARATOR)
-        exts = [''] if exts.empty?
-        ENV.fetch('PATH', '').split(File::PATH_SEPARATOR).each do |dir|
-          exts.each do |ext|
-            candidate = File.join(dir, "#{cmd}#{ext}")
-            return candidate if File.file?(candidate) && File.executable?(candidate)
-          end
-        end
-        nil
       end
 
       def run_process(cmd, src_path, stdin, timeout_seconds, output_path)

--- a/lib/trmnlp/transform_backend/subprocess.rb
+++ b/lib/trmnlp/transform_backend/subprocess.rb
@@ -19,11 +19,16 @@ module TRMNLP
       # Seconds a TERM'd process is given to exit before escalating to KILL.
       GRACE_PERIOD = 0.1
 
+      # Each language lists its interpreter command candidates in priority
+      # order. The first one found on PATH wins, so transforms stay portable
+      # across platforms that name the same interpreter differently — most
+      # notably Windows, where Python is installed as `python` with no
+      # `python3` on PATH.
       INTERPRETERS = {
-        'python' => { cmd: 'python3', ext: 'py' },
-        'ruby' => { cmd: 'ruby',    ext: 'rb' },
-        'node' => { cmd: 'node',    ext: 'js' },
-        'php' => { cmd: 'php', ext: 'php' }
+        'python' => { cmds: %w[python3 python], ext: 'py' },
+        'ruby' => { cmds: %w[ruby],             ext: 'rb' },
+        'node' => { cmds: %w[node],             ext: 'js' },
+        'php' => { cmds: %w[php],               ext: 'php' }
       }.freeze
 
       def execute(code:, language:, stdin: '', timeout_seconds: DEFAULT_TIMEOUT)
@@ -40,10 +45,33 @@ module TRMNLP
           output_path = File.join(dir, 'output.json')
           src_path = File.join(dir, "transform.#{spec[:ext]}")
           File.write(src_path, Wrapper.for(language, code, sink_for(language, output_path)))
-          run_process(spec[:cmd], src_path, stdin, timeout_seconds, output_path)
+          run_process(resolve_cmd(spec[:cmds]), src_path, stdin, timeout_seconds, output_path)
         end
       rescue Errno::ENOENT, Errno::EACCES => e
         failure("interpreter not available: #{e.message}")
+      end
+
+      # First candidate present on PATH, falling back to the first name so a
+      # genuinely missing interpreter still surfaces a sensible
+      # "interpreter not available" error from run_process.
+      def resolve_cmd(cmds)
+        cmds.find { |c| which(c) } || cmds.first
+      end
+
+      # Minimal cross-platform `which`. On Windows PATHEXT lists the
+      # executable suffixes (.EXE/.BAT/...) to try; on POSIX it is unset, so
+      # we fall back to a single bare-name lookup. File.executable? maps to
+      # the exec bit on POSIX and to a recognized extension on Windows.
+      def which(cmd)
+        exts = ENV.fetch('PATHEXT', '').split(File::PATH_SEPARATOR)
+        exts = [''] if exts.empty?
+        ENV.fetch('PATH', '').split(File::PATH_SEPARATOR).each do |dir|
+          exts.each do |ext|
+            candidate = File.join(dir, "#{cmd}#{ext}")
+            return candidate if File.file?(candidate) && File.executable?(candidate)
+          end
+        end
+        nil
       end
 
       def run_process(cmd, src_path, stdin, timeout_seconds, output_path)

--- a/lib/trmnlp/transform_backend/which.rb
+++ b/lib/trmnlp/transform_backend/which.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module TRMNLP
+  module TransformBackend
+    # Resolves a command to the interpreter actually present on PATH, so one
+    # transform runs unchanged on platforms that name an interpreter
+    # differently — most pressingly Windows, which ships no `python3`.
+    module Which
+      module_function
+
+      # Falls back to the first candidate when none resolve, leaving the
+      # caller to surface the usual "interpreter not available" ENOENT.
+      def resolve(candidates, path: ENV.fetch('PATH', ''), pathext: ENV.fetch('PATHEXT', ''))
+        candidates.find { |cmd| locate(cmd, path: path, pathext: pathext) } || candidates.first
+      end
+
+      # Windows marks executables by extension, enumerated in PATHEXT
+      # (.EXE/.BAT/...); POSIX leaves PATHEXT unset and relies on the exec bit.
+      def locate(cmd, path: ENV.fetch('PATH', ''), pathext: ENV.fetch('PATHEXT', ''))
+        suffixes = pathext.split(File::PATH_SEPARATOR)
+        suffixes = [''] if suffixes.empty?
+        path.split(File::PATH_SEPARATOR)
+            .product(suffixes)
+            .map { |dir, suffix| File.join(dir, "#{cmd}#{suffix}") }
+            .find { |candidate| File.file?(candidate) && File.executable?(candidate) }
+      end
+    end
+  end
+end

--- a/lib/trmnlp/version.rb
+++ b/lib/trmnlp/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TRMNLP
-  VERSION = '0.8.9'
+  VERSION = '0.8.10'
 end

--- a/spec/lib/trmnlp/transform_backend/subprocess_spec.rb
+++ b/spec/lib/trmnlp/transform_backend/subprocess_spec.rb
@@ -94,13 +94,28 @@ RSpec.describe TRMNLP::TransformBackend::Subprocess do
 
     it 'reports the interpreter command as failure when it is not on PATH' do
       stub_const("#{described_class}::INTERPRETERS", {
-                   'ghost' => { cmd: 'this-binary-does-not-exist', ext: 'rb', wrapper: :ruby_wrapper }
+                   'ghost' => { cmds: %w[this-binary-does-not-exist], ext: 'rb' }
                  })
 
       result = backend.execute(code: 'noop', language: 'ghost', stdin: '')
 
       expect(result).not_to be_success
       expect(result.error).to match(/interpreter not available/)
+    end
+
+    it 'falls back to the next interpreter candidate when the first is missing (Windows has `python`, not `python3`)' do
+      stub_const("#{described_class}::INTERPRETERS", {
+                   'python' => { cmds: %w[this-binary-does-not-exist python3], ext: 'py' }
+                 })
+
+      result = backend.execute(
+        code: "def run(input):\n    return { 'echoed': input['greeting'] }",
+        language: 'python',
+        stdin: JSON.generate('greeting' => 'hello')
+      )
+
+      expect(result).to be_success
+      expect(JSON.parse(result.output)).to eq('echoed' => 'hello')
     end
   end
 end

--- a/spec/lib/trmnlp/transform_backend/subprocess_spec.rb
+++ b/spec/lib/trmnlp/transform_backend/subprocess_spec.rb
@@ -102,20 +102,5 @@ RSpec.describe TRMNLP::TransformBackend::Subprocess do
       expect(result).not_to be_success
       expect(result.error).to match(/interpreter not available/)
     end
-
-    it 'falls back to the next interpreter candidate when the first is missing (Windows has `python`, not `python3`)' do
-      stub_const("#{described_class}::INTERPRETERS", {
-                   'python' => { cmds: %w[this-binary-does-not-exist python3], ext: 'py' }
-                 })
-
-      result = backend.execute(
-        code: "def run(input):\n    return { 'echoed': input['greeting'] }",
-        language: 'python',
-        stdin: JSON.generate('greeting' => 'hello')
-      )
-
-      expect(result).to be_success
-      expect(JSON.parse(result.output)).to eq('echoed' => 'hello')
-    end
   end
 end

--- a/spec/lib/trmnlp/transform_backend/which_spec.rb
+++ b/spec/lib/trmnlp/transform_backend/which_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'fileutils'
+require 'tmpdir'
+require 'trmnlp/transform_backend/which'
+
+RSpec.describe TRMNLP::TransformBackend::Which do
+  subject(:which) { described_class }
+
+  let(:bin) { Dir.mktmpdir('trmnlp-which-') }
+  # Joined with the platform separator so the PATHEXT split matches Windows
+  # (`;`) and POSIX (`:`) without the spec caring which it runs on.
+  let(:windows_pathext) { ['.COM', '.BAT'].join(File::PATH_SEPARATOR) }
+
+  after { FileUtils.remove_entry(bin) }
+
+  describe '.locate' do
+    it 'answers the full path of an executable found on PATH' do
+      executable = File.join(bin, 'widget')
+      File.write(executable, '')
+      File.chmod(0o755, executable)
+
+      expect(which.locate('widget', path: bin)).to eq(executable)
+    end
+
+    it 'answers nil when the command is absent from PATH' do
+      expect(which.locate('ghost', path: bin)).to be(nil)
+    end
+
+    it 'ignores a matching file that is not executable' do
+      File.write(File.join(bin, 'widget'), '')
+
+      expect(which.locate('widget', path: bin)).to be(nil)
+    end
+
+    it 'appends a PATHEXT suffix when locating a Windows executable' do
+      executable = File.join(bin, 'widget.BAT')
+      File.write(executable, '')
+      File.chmod(0o755, executable)
+
+      expect(which.locate('widget', path: bin, pathext: windows_pathext)).to eq(executable)
+    end
+  end
+
+  describe '.resolve' do
+    it 'answers the first candidate present on PATH' do
+      %w[python py].each do |name|
+        File.write(File.join(bin, name), '')
+        File.chmod(0o755, File.join(bin, name))
+      end
+
+      expect(which.resolve(%w[python3 python py], path: bin)).to eq('python')
+    end
+
+    it 'answers the highest-priority candidate when several are present' do
+      %w[python3 python].each do |name|
+        File.write(File.join(bin, name), '')
+        File.chmod(0o755, File.join(bin, name))
+      end
+
+      expect(which.resolve(%w[python3 python py], path: bin)).to eq('python3')
+    end
+
+    it 'answers the first candidate name when none resolve, preserving the ENOENT path' do
+      expect(which.resolve(%w[python3 python py], path: bin)).to eq('python3')
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Serverless transforms fail on Windows whenever the transform is Python (`src/transform.py`). `Subprocess` hardcodes the interpreter command as `python3`:

```ruby
INTERPRETERS = {
  'python' => { cmd: 'python3', ext: 'py' },
  ...
}.freeze
```

The python.org Windows installer provides `python.exe` and the `py` launcher but **no `python3` on PATH** (only the Microsoft Store build registers a `python3` alias). So `Open3.popen3('python3', ...)` raises `Errno::ENOENT`, which surfaces to the user as **"interpreter not available"**, and there's no config to point it at `python`.

## Fix

Make each language's interpreter a list of **command candidates** in priority order, and run the first one found on PATH:

```ruby
'python' => { cmds: %w[python3 python], ext: 'py' },
```

Resolution uses a small cross-platform `which` that honors `PATHEXT` on Windows (`.EXE`/`.BAT`/…) and bare names on POSIX. Behavior is unchanged on macOS/Linux (`python3` still wins); Windows now falls back to `python`. A genuinely missing interpreter falls back to the first candidate, so the existing "interpreter not available" error path is preserved.

No new dependencies, no config knobs — transforms just work across platforms.

## Tests

- Updated the existing PATH-failure spec to the new `cmds:` shape.
- Added a spec proving candidate fallback: first candidate missing → next one runs.

`bundle exec rspec spec/lib/trmnlp/transform_backend/subprocess_spec.rb` passes (the unrelated `php` example needs php installed locally); `rubocop` clean on both files.