### PR TITLE
Use python instead of python3 on windows

### DIFF
--- a/lib/trmnlp/transform_backend/subprocess.rb
+++ b/lib/trmnlp/transform_backend/subprocess.rb
@@ -20,7 +20,7 @@ module TRMNLP
       GRACE_PERIOD = 0.1
 
       INTERPRETERS = {
-        'python' => { cmd: 'python3', ext: 'py' },
+        'python' => { cmd: (Gem.win_platform? ? 'python' : 'python3'), ext: 'py' },
         'ruby' => { cmd: 'ruby',    ext: 'rb' },
         'node' => { cmd: 'node',    ext: 'js' },
         'php' => { cmd: 'php', ext: 'php' }


### PR DESCRIPTION
Fixes trmnlp not being able to detect python for serverless transforms on windows