### PR TITLE
Bump version to 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 
 # Changelog
 
-## Unreleased
+## 0.10.0
 
 - Added support for the `description` plugin setting, an optional one-line summary of the plugin. `trmnlp init` scaffolds the key in `src/settings.yml`, `trmnlp lint` reports descriptions longer than 35 characters (the hosted service's limit), and `trmnlp list` shows a DESCRIPTION column when any plugin has one. Only the length is checked. Storing the value needs the matching hosted service release; until then `trmnlp push` drops it, because it rewrites the local `settings.yml` from the server's response.
 - `trmnlp push` now offers to delete the server-side transform script when the project has no local `transform.*` file. Previously, deleting the file locally was a silent no-op: the server kept executing its copy and every `trmnlp pull` re-created the file. Answering yes sends `serverless_language: none` in the pushed settings.yml, which the server consumes as an explicit removal request. `--force` pushes skip the question and behave exactly as before; a failed server check never blocks the push.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trmnl_preview (0.9.0)
+    trmnl_preview (0.10.0)
       activesupport (~> 8.0)
       cgi (~> 0.5)
       faraday (~> 2.1)

--- a/lib/trmnlp/version.rb
+++ b/lib/trmnlp/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TRMNLP
-  VERSION = '0.9.0'
+  VERSION = '0.10.0'
 end


### PR DESCRIPTION
Cuts 0.10.0. Minor bump because the unreleased entries add features rather than fix bugs.

- Moves the Unreleased changelog section under a 0.10.0 heading (description plugin setting, transform deletion prompt on push)
- Bumps TRMNLP::VERSION and Gemfile.lock

Merging this triggers the release workflow: tag, gem publish, multi-arch Docker image.