### PR TITLE
Read the framework version list from the published manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 
 # Changelog
 
+## Unreleased
+
+- `framework_version:` now resolves against the release manifest published by the design system, not only the version list shipped inside the gem, so a framework version released after your trmnlp install can be pinned without upgrading. The manifest is read once per run with a 2 second timeout. If the request fails, or the response is not a version list, the copy bundled in the gem is used and rendering continues. That bundled copy is refreshed here too: `latest` moves from 3.1.1 to 3.2.0.
+- `rake framework:sync` reads the published manifest by default. Pass a local design-system checkout (`rake framework:sync[/path/to/repo]`) for the previous behaviour.
+
 ## 0.10.0
 
 - Added support for the `description` plugin setting, an optional one-line summary of the plugin. `trmnlp init` scaffolds the key in `src/settings.yml`, `trmnlp lint` reports descriptions longer than 35 characters (the hosted service's limit), and `trmnlp list` shows a DESCRIPTION column when any plugin has one. Only the length is checked. Storing the value needs the matching hosted service release; until then `trmnlp push` drops it, because it rewrites the local `settings.yml` from the server's response.

--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ A complete worked example lives at [`examples/hn-stories/`](examples/hn-stories/
 
 The `settings.yml` file is part of the plugin definition, and is uploaded and downloaded by `trmnlp push` / `pull`.
 
-`framework_version:` pins the [TRMNL Design System](https://trmnl.com/framework) version this plugin renders against — `latest` (the default) tracks the newest release, or set a specific version for reproducibility. It lives here rather than in `.trmnlp.yml` so the value round-trips with the hosted plugin service.
+`framework_version:` pins the [TRMNL Design System](https://trmnl.com/framework) version this plugin renders against — `latest` (the default) tracks the newest release, or set a specific version for reproducibility. It lives here rather than in `.trmnlp.yml` so the value round-trips with the hosted plugin service. The list of pinnable versions is read from the [design system's published manifest](https://github.com/usetrmnl/trmnl-framework) once per run, so a newly released version can be pinned without upgrading trmnlp. If that request fails, the copy bundled in the gem is used.
 
 `description:` is an optional one-line summary of the plugin, up to 35 characters. `trmnlp lint` reports anything longer, and `trmnlp list` shows it next to each plugin name.
 

--- a/Rakefile
+++ b/Rakefile
@@ -10,19 +10,23 @@ RuboCop::RakeTask.new
 task default: :spec
 
 namespace :framework do
-  desc 'Sync db/data/framework_versions.yml from a local design-system checkout'
+  desc 'Sync db/data/framework_versions.yml from the published design-system manifest'
   task :sync, [:source_repo] do |_t, args|
+    require 'open-uri'
+    require_relative 'lib/trmnlp/framework_version'
+
     source_repo = args[:source_repo] || ENV.fetch('FRAMEWORK_SOURCE_REPO', nil)
-    if source_repo.nil?
-      abort 'Provide the source checkout: rake framework:sync[/path/to/repo] (or FRAMEWORK_SOURCE_REPO=...)'
+
+    if source_repo
+      source = File.expand_path(File.join(source_repo, 'db', 'data', 'framework_versions.yml'))
+      abort "Source file not found: #{source}" unless File.exist?(source)
+      contents = File.read(source)
+    else
+      source = TRMNLP::FrameworkVersion::MANIFEST_URL
+      contents = URI.parse(source).read
     end
 
-    source = File.expand_path(File.join(source_repo, 'db', 'data', 'framework_versions.yml'))
-
-    abort "Source file not found: #{source}" unless File.exist?(source)
-
     destination = File.expand_path('db/data/framework_versions.yml', __dir__)
-    contents = File.read(source)
     header = <<~HEADER
       # Mirrored from the TRMNL design-system source.
       # Refresh with `rake framework:sync` — do not edit manually.

--- a/db/data/framework_versions.yml
+++ b/db/data/framework_versions.yml
@@ -1,6 +1,6 @@
 # Mirrored from the TRMNL design-system source.
 # Refresh with `rake framework:sync` — do not edit manually.
-latest: 3.1.1
+latest: 3.2.0
 versions:
 - number: 0.0.1
   released_at: '2024-06-22'
@@ -70,3 +70,19 @@ versions:
   released_at: '2026-04-29'
 - number: 3.1.1
   released_at: '2026-05-01'
+- number: 3.1.2
+  released_at: '2026-07-09'
+- number: 3.1.3
+  released_at: '2026-07-14'
+- number: 3.1.4
+  released_at: '2026-07-15'
+- number: 3.1.5
+  released_at: '2026-07-16'
+- number: 3.1.6
+  released_at: '2026-07-17'
+- number: 3.1.7
+  released_at: '2026-07-18'
+- number: 3.1.8
+  released_at: '2026-07-23'
+- number: 3.2.0
+  released_at: '2026-08-03'

--- a/lib/trmnlp/framework_version.rb
+++ b/lib/trmnlp/framework_version.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'faraday'
 require 'yaml'
 
 module TRMNLP
@@ -11,10 +12,29 @@ module TRMNLP
 
     DEFAULT_ASSET_HOST = 'https://trmnl.com'
     DATA_PATH = File.expand_path('../../db/data/framework_versions.yml', __dir__)
+    # DATA_PATH holds a copy of this file, refreshed by `rake framework:sync`.
+    MANIFEST_URL = 'https://raw.githubusercontent.com/usetrmnl/trmnl-framework/main/db/data/framework_versions.yml'
+    MANIFEST_TIMEOUT = 2
 
     attr_reader :number
 
-    def self.config = @config ||= YAML.load_file(DATA_PATH).freeze
+    def self.config = @config ||= (remote_config || YAML.load_file(DATA_PATH)).freeze
+
+    # Answers nil on any failure, so rendering never depends on the network.
+    # The shape check rejects error pages, which are also valid YAML.
+    def self.remote_config
+      response = Faraday.get(MANIFEST_URL) do |request|
+        request.options.open_timeout = MANIFEST_TIMEOUT
+        request.options.timeout = MANIFEST_TIMEOUT
+      end
+      return unless response.success?
+
+      manifest = YAML.safe_load(response.body)
+      manifest if manifest.is_a?(Hash) && manifest.key?('latest') && manifest.key?('versions')
+    rescue StandardError
+      nil
+    end
+    private_class_method :remote_config
 
     def self.version_numbers = config.fetch('versions').map { |v| v['number'] }.freeze
 

--- a/spec/lib/trmnlp/framework_version_spec.rb
+++ b/spec/lib/trmnlp/framework_version_spec.rb
@@ -4,76 +4,178 @@ require 'spec_helper'
 require 'trmnlp/framework_version'
 
 RSpec.describe TRMNLP::FrameworkVersion do
-  describe '.latest' do
-    subject(:latest) { described_class.latest }
+  subject(:framework) { described_class.new('1.0.0') }
 
-    it 'is pinned' do
-      expect(latest).to be_pinned
+  let(:bundled) { YAML.load_file(described_class::DATA_PATH) }
+
+  describe '.config' do
+    let(:published) { { 'latest' => '99.1.0', 'versions' => [{ 'number' => '99.1.0' }] } }
+
+    around do |example|
+      memoized = described_class.instance_variable_get(:@config)
+      described_class.instance_variable_set(:@config, nil)
+      example.run
+      described_class.instance_variable_set(:@config, memoized)
     end
 
-    it 'has a version number' do
-      expect(latest.number).to match(/\A\d+\.\d+\.\d+\z/)
+    it 'answers the published manifest' do
+      stub_request(:get, described_class::MANIFEST_URL).to_return(body: published.to_yaml)
+
+      expect(described_class.config).to eq(published)
+    end
+
+    it 'answers the bundled copy when the manifest is unreachable' do
+      stub_request(:get, described_class::MANIFEST_URL).to_timeout
+
+      expect(described_class.config).to eq(bundled)
+    end
+
+    it 'answers the bundled copy when the request fails' do
+      stub_request(:get, described_class::MANIFEST_URL).to_return(status: 500)
+
+      expect(described_class.config).to eq(bundled)
+    end
+
+    it 'answers the bundled copy when the response is not a manifest' do
+      stub_request(:get, described_class::MANIFEST_URL).to_return(body: '<html>Not Found</html>')
+
+      expect(described_class.config).to eq(bundled)
+    end
+
+    it 'reads the manifest once' do
+      described_class.config
+      described_class.config
+
+      expect(WebMock).to have_requested(:get, described_class::MANIFEST_URL).once
     end
   end
 
-  describe '#css_url and #js_url' do
-    context 'when version is "latest"' do
+  describe '.version_numbers' do
+    it 'answers every number in the manifest' do
+      numbers = bundled.fetch('versions').map { |version| version['number'] }
+
+      expect(described_class.version_numbers).to eq(numbers)
+    end
+  end
+
+  describe '.latest' do
+    it 'answers the manifest latest' do
+      expect(described_class.latest.number).to eq(bundled.fetch('latest'))
+    end
+
+    it 'is pinned' do
+      expect(described_class.latest.pinned?).to be(true)
+    end
+  end
+
+  describe '.options' do
+    it 'answers latest as the first option' do
+      label = "Always track latest (currently v#{bundled.fetch('latest')})"
+
+      expect(described_class.options.first).to eq(label => 'latest')
+    end
+
+    it 'orders the pinnable versions newest-first by semantic version' do
+      pinned = described_class.options.drop(1).map { |option| option.values.first }
+
+      expect(pinned).to eq(pinned.sort_by { |number| Gem::Version.new(number) }.reverse)
+    end
+  end
+
+  describe '#initialize' do
+    it 'answers the latest number when given nil' do
+      expect(described_class.new(nil).number).to eq(bundled.fetch('latest'))
+    end
+
+    it 'raises an argument error when given an unknown version' do
+      expectation = proc { described_class.new('99.99.99') }
+
+      expect(&expectation).to raise_error(ArgumentError, /unknown framework version/)
+    end
+  end
+
+  describe '#pinned?' do
+    it 'answers true when given a version' do
+      expect(framework.pinned?).to be(true)
+    end
+
+    it 'answers false when given latest' do
+      expect(described_class.new('latest').pinned?).to be(false)
+    end
+  end
+
+  describe '#css_url' do
+    it 'answers the version-specific path' do
+      expect(framework.css_url).to eq('https://trmnl.com/css/1.0.0/plugins.css')
+    end
+
+    context 'when tracking latest' do
       subject(:framework) { described_class.new('latest') }
 
       # NOTE: "latest" resolves to a concrete version rather than the
       # auto-upgrading /latest/ CDN path, matching the hosted service —
       # otherwise a local preview silently drifts when a new release ships.
-      it 'serves from the concrete current version' do
-        number = described_class.latest.number
-
-        expect(framework.css_url).to eq("https://trmnl.com/css/#{number}/plugins.css")
-        expect(framework.js_url).to eq("https://trmnl.com/js/#{number}/plugins.js")
-      end
-    end
-
-    context 'when a specific version is pinned' do
-      subject(:framework) { described_class.new('1.0.0') }
-
-      it 'serves from the version-specific path' do
-        expect(framework.css_url).to eq('https://trmnl.com/css/1.0.0/plugins.css')
-        expect(framework.js_url).to eq('https://trmnl.com/js/1.0.0/plugins.js')
+      it 'answers the concrete current version' do
+        expect(framework.css_url).to eq("https://trmnl.com/css/#{bundled.fetch('latest')}/plugins.css")
       end
     end
 
     context 'with a custom asset host' do
       subject(:framework) { described_class.new('1.0.0', asset_host: 'https://cdn.example.com') }
 
-      it 'honours the override' do
+      it 'answers the override host' do
         expect(framework.css_url).to eq('https://cdn.example.com/css/1.0.0/plugins.css')
       end
     end
   end
 
-  describe '#initialize' do
-    it 'accepts nil as latest' do
-      expect(described_class.new(nil)).not_to be_pinned
+  describe '#js_url' do
+    it 'answers the version-specific path' do
+      expect(framework.js_url).to eq('https://trmnl.com/js/1.0.0/plugins.js')
     end
 
-    it 'raises on an unknown version' do
-      expect { described_class.new('99.99.99') }
-        .to raise_error(ArgumentError, /unknown framework version/)
+    context 'with a custom asset host' do
+      subject(:framework) { described_class.new('1.0.0', asset_host: 'https://cdn.example.com') }
+
+      it 'answers the override host' do
+        expect(framework.js_url).to eq('https://cdn.example.com/js/1.0.0/plugins.js')
+      end
+    end
+  end
+
+  describe '#==' do
+    it 'answers true for the same number' do
+      expect(framework == described_class.new('1.0.0')).to be(true)
+    end
+
+    it 'answers false for a different number' do
+      expect(framework == described_class.new('2.0.0')).to be(false)
+    end
+
+    it 'answers false for a different type' do
+      expect(framework == '1.0.0').to be(false)
     end
   end
 
   describe '#<=>' do
     it 'orders by semantic version' do
-      v1 = described_class.new('1.0.0')
-      v2 = described_class.new('2.0.0')
+      expect(framework).to be < described_class.new('2.0.0')
+    end
 
-      expect(v1).to be < v2
+    it 'answers nil for a different type' do
+      expect(framework <=> '1.0.0').to be(nil)
     end
   end
 
-  describe '.options' do
-    it 'orders the pinnable versions newest-first by semantic version' do
-      pinned = described_class.options.drop(1).map { |option| option.values.first }
+  describe '#as_json' do
+    it 'answers the number' do
+      expect(framework.as_json).to eq('1.0.0')
+    end
+  end
 
-      expect(pinned).to eq(pinned.sort_by { |number| Gem::Version.new(number) }.reverse)
+  describe '#to_s' do
+    it 'answers the number' do
+      expect(framework.to_s).to eq('1.0.0')
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,6 +33,13 @@ RSpec.configure do |config|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end
 
+  # Serves the bundled copy of the framework manifest, so specs assert
+  # against a fixed version list instead of whatever is published today.
+  config.before do
+    stub_request(:get, TRMNLP::FrameworkVersion::MANIFEST_URL)
+      .to_return(body: File.read(TRMNLP::FrameworkVersion::DATA_PATH))
+  end
+
   config.mock_with :rspec do |mocks|
     mocks.verify_doubled_constant_names = true
     mocks.verify_partial_doubles = true


### PR DESCRIPTION
The list of pinnable `framework_version:` values came only from `db/data/framework_versions.yml` inside the gem, so a design system release needed a trmnlp release before anyone could pin it. That file is now published in the public design system repo, so trmnlp reads it from there.

- reads the manifest once per run, with a 2 second timeout
- falls back to the bundled copy when the request fails or the response is not a version list
- refreshes the bundled copy: `latest` moves from 3.1.1 to 3.2.0
- `rake framework:sync` now reads the published manifest by default; pass a local checkout for the previous behaviour
- specs cover both sources and the single read, with the bundled copy stubbed in for the suite