### PR TITLE
Bump version to 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 
 # Changelog
 
-## Unreleased
+## 0.11.0
 
 - `framework_version:` now resolves against the release manifest published by the design system, not only the version list shipped inside the gem, so a framework version released after your trmnlp install can be pinned without upgrading. The manifest is read once per run with a 2 second timeout. If the request fails, or the response is not a version list, the copy bundled in the gem is used and rendering continues. That bundled copy is refreshed here too: `latest` moves from 3.1.1 to 3.2.0.
 - `rake framework:sync` reads the published manifest by default. Pass a local design-system checkout (`rake framework:sync[/path/to/repo]`) for the previous behaviour.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trmnl_preview (0.10.0)
+    trmnl_preview (0.11.0)
       activesupport (~> 8.0)
       cgi (~> 0.5)
       faraday (~> 2.1)

--- a/lib/trmnlp/framework_version.rb
+++ b/lib/trmnlp/framework_version.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'date'
 require 'faraday'
 require 'yaml'
 
@@ -29,7 +30,9 @@ module TRMNLP
       end
       return unless response.success?
 
-      manifest = YAML.safe_load(response.body)
+      # Release dates are quoted today, but the manifest is generated
+      # upstream and an unquoted date would otherwise be rejected here.
+      manifest = YAML.safe_load(response.body, permitted_classes: [Date])
       manifest if manifest.is_a?(Hash) && manifest.key?('latest') && manifest.key?('versions')
     rescue StandardError
       nil

--- a/lib/trmnlp/version.rb
+++ b/lib/trmnlp/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TRMNLP
-  VERSION = '0.10.0'
+  VERSION = '0.11.0'
 end

--- a/spec/lib/trmnlp/framework_version_spec.rb
+++ b/spec/lib/trmnlp/framework_version_spec.rb
@@ -24,6 +24,13 @@ RSpec.describe TRMNLP::FrameworkVersion do
       expect(described_class.config).to eq(published)
     end
 
+    it 'answers a manifest with unquoted release dates' do
+      body = "latest: 99.1.0\nversions:\n- number: 99.1.0\n  released_at: 2026-08-03\n"
+      stub_request(:get, described_class::MANIFEST_URL).to_return(body:)
+
+      expect(described_class.version_numbers).to eq(['99.1.0'])
+    end
+
     it 'answers the bundled copy when the manifest is unreachable' do
       stub_request(:get, described_class::MANIFEST_URL).to_timeout
 


### PR DESCRIPTION
Releases the framework manifest change, plus a follow-up that did not make it into the #124 squash.

- accepts unquoted release dates in the published manifest, so a generator change upstream does not silently drop trmnlp back to the bundled copy
- version.rb, Gemfile.lock, and the CHANGELOG heading for 0.11.0
- bundled manifest is already on main at `latest` 3.2.0

Checked before pushing: 424 specs green, rubocop clean, gem builds with the refreshed manifest inside, and a served plugin renders `https://trmnl.com/css/3.2.0/plugins.css` on `latest` and 3.1.5 when pinned.